### PR TITLE
[Mellanox] Add new patches come along with hw-mgmt V.7.0000.3034

### DIFF
--- a/patch/0058-mlxsw-core-thermal-Set-default-thermal-trips-at-init.patch
+++ b/patch/0058-mlxsw-core-thermal-Set-default-thermal-trips-at-init.patch
@@ -1,0 +1,49 @@
+From a50b84e93f743c13f2568396927c7744ff706e29 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Mon, 23 Mar 2020 12:57:16 +0200
+Subject: [thermal_emul 1/2] mlxsw: core: thermal: Set default thermal trips at
+ initialization
+
+Set default thermal trip temperatures during thermal zone
+initialization. Otherwise polling time for thermal control
+could stay zero and such thermal zones will not be triggered by
+thermal algorithm.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+index 690ae0f1820e..53198e260633 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+@@ -20,6 +20,10 @@
+ #define MLXSW_THERMAL_ASIC_TEMP_HIGH	85000	/* 85C */
+ #define MLXSW_THERMAL_ASIC_TEMP_HOT	105000	/* 105C */
+ #define MLXSW_THERMAL_ASIC_TEMP_CRIT	110000	/* 110C */
++#define MLXSW_THERMAL_MODULE_TEMP_NORM	60000	/* 60C */
++#define MLXSW_THERMAL_MODULE_TEMP_HIGH	70000	/* 70C */
++#define MLXSW_THERMAL_MODULE_TEMP_HOT	80000	/* 80C */
++#define MLXSW_THERMAL_MODULE_TEMP_CRIT	90000	/* 90C */
+ #define MLXSW_THERMAL_HYSTERESIS_TEMP	5000	/* 5C */
+ #define MLXSW_THERMAL_MODULE_TEMP_SHIFT	(MLXSW_THERMAL_HYSTERESIS_TEMP * 2)
+ #define MLXSW_THERMAL_ZONE_MAX_NAME	16
+@@ -154,10 +158,10 @@ static int mlxsw_get_cooling_device_idx(struct mlxsw_thermal *thermal,
+ static void
+ mlxsw_thermal_module_trips_reset(struct mlxsw_thermal_module *tz)
+ {
+-	tz->trips[MLXSW_THERMAL_TEMP_TRIP_NORM].temp = 0;
+-	tz->trips[MLXSW_THERMAL_TEMP_TRIP_HIGH].temp = 0;
+-	tz->trips[MLXSW_THERMAL_TEMP_TRIP_HOT].temp = 0;
+-	tz->trips[MLXSW_THERMAL_TEMP_TRIP_CRIT].temp = 0;
++	tz->trips[MLXSW_THERMAL_TEMP_TRIP_NORM].temp = MLXSW_THERMAL_MODULE_TEMP_NORM;
++	tz->trips[MLXSW_THERMAL_TEMP_TRIP_HIGH].temp = MLXSW_THERMAL_MODULE_TEMP_HIGH;
++	tz->trips[MLXSW_THERMAL_TEMP_TRIP_HOT].temp = MLXSW_THERMAL_MODULE_TEMP_HOT;
++	tz->trips[MLXSW_THERMAL_TEMP_TRIP_CRIT].temp = MLXSW_THERMAL_MODULE_TEMP_CRIT;
+ }
+ 
+ static int
+-- 
+2.11.0
+

--- a/patch/0059-mlxsw-core-Add-the-hottest-thermal-zone-detection.patch
+++ b/patch/0059-mlxsw-core-Add-the-hottest-thermal-zone-detection.patch
@@ -1,0 +1,165 @@
+From a975f22abc2b75614f5a58ea8af843043ade782f Mon Sep 17 00:00:00 2001
+From: junchao <junchao@contoso.com>
+Date: Mon, 30 Mar 2020 10:05:25 +0000
+Subject: [hwmon-next 04/14] mlxsw: core: Add the hottest thermal zone
+ detection
+
+When multiple sensors are mapped to the same cooling device, the
+cooling device should be set according the worst sensor from the
+sensors associated with this cooling device.
+
+Provide the hottest thermal zone detection and enforce cooling device
+to follow the temperature trends of the hottest zone only.
+Prevent competition for the cooling device control from others zones,
+by "stable trend" indication. A cooling device will not perform any
+actions associated with a zone with a "stable trend".
+
+When other thermal zone is detected as a hottest, a cooling device is
+to be switched to following temperature trends of new hottest zone.
+
+Thermal zone score is represented by 32 bits unsigned integer and
+calculated according to the next formula:
+For T < TZ<t><i>, where t from {normal trip = 0, high trip = 1, hot
+trip = 2, critical = 3}:
+TZ<i> score = (T + (TZ<t><i> - T) / 2) / (TZ<t><i> - T) * 256 ** j;
+Highest thermal zone score s is set as MAX(TZ<i>score);
+Following this formula, if TZ<i> is in trip point higher than TZ<k>,
+the higher score is to be always assigned to TZ<i>.
+
+For two thermal zones located at the same kind of trip point, the higher
+score will be assigned to the zone which is closer to the next trip
+point. Thus, the highest score will always be assigned objectively to
+the hottest thermal zone.
+
+All the thermal zones initially are to be configured with mode
+"enabled" with the "step_wise" governor.
+
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 55 ++++++++++++++++++++++
+ 1 file changed, 55 insertions(+)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+index e1e18ea..53198e2 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+@@ -27,6 +27,7 @@
+ #define MLXSW_THERMAL_HYSTERESIS_TEMP	5000	/* 5C */
+ #define MLXSW_THERMAL_MODULE_TEMP_SHIFT	(MLXSW_THERMAL_HYSTERESIS_TEMP * 2)
+ #define MLXSW_THERMAL_ZONE_MAX_NAME	16
++#define MLXSW_THERMAL_TEMP_SCORE_MAX	GENMASK(31, 0)
+ #define MLXSW_THERMAL_MAX_STATE	10
+ #define MLXSW_THERMAL_MAX_DUTY	255
+ /* Minimum and maximum fan allowed speed in percent: from 20% to 100%. Values
+@@ -205,6 +206,34 @@ mlxsw_thermal_module_trips_update(struct device *dev, struct mlxsw_core *core,
+ 	return 0;
+ }
+ 
++static void mlxsw_thermal_tz_score_update(struct mlxsw_thermal *thermal,
++					  struct thermal_zone_device *tzdev,
++					  struct mlxsw_thermal_trip *trips,
++					  int temp)
++{
++	struct mlxsw_thermal_trip *trip = trips;
++	unsigned int score, delta, i, shift = 1;
++
++	/* Calculate thermal zone score, if temperature is above the critical
++	 * threshold score is set to MLXSW_THERMAL_TEMP_SCORE_MAX.
++	 */
++	score = MLXSW_THERMAL_TEMP_SCORE_MAX;
++	for (i = MLXSW_THERMAL_TEMP_TRIP_NORM; i < MLXSW_THERMAL_NUM_TRIPS;
++	     i++, trip++) {
++		if (temp < trip->temp) {
++			delta = DIV_ROUND_CLOSEST(temp, trip->temp - temp);
++			score = delta * shift;
++			break;
++		}
++		shift *= 256;
++	}
++
++	if (score > thermal->tz_highest_score) {
++		thermal->tz_highest_score = score;
++		thermal->tz_highest_dev = tzdev;
++	}
++}
++
+ static int mlxsw_thermal_bind(struct thermal_zone_device *tzdev,
+ 			      struct thermal_cooling_device *cdev)
+ {
+@@ -306,6 +335,9 @@ static int mlxsw_thermal_get_temp(struct thermal_zone_device *tzdev,
+ 		return err;
+ 	}
+ 	mlxsw_reg_mtmp_unpack(mtmp_pl, &temp, NULL, NULL);
++	if (temp > 0)
++		mlxsw_thermal_tz_score_update(thermal, tzdev, thermal->trips,
++					      temp);
+ 
+ 	*p_temp = temp;
+ 	return 0;
+@@ -367,6 +399,22 @@ static int mlxsw_thermal_set_trip_hyst(struct thermal_zone_device *tzdev,
+ 	return 0;
+ }
+ 
++static int mlxsw_thermal_trend_get(struct thermal_zone_device *tzdev,
++				   int trip, enum thermal_trend *trend)
++{
++	struct mlxsw_thermal_module *tz = tzdev->devdata;
++	struct mlxsw_thermal *thermal = tz->parent;
++
++	if (trip < 0 || trip >= MLXSW_THERMAL_NUM_TRIPS)
++		return -EINVAL;
++
++	if (tzdev == thermal->tz_highest_dev)
++		return 1;
++
++	*trend = THERMAL_TREND_STABLE;
++	return 0;
++}
++
+ struct thermal_zone_params mlxsw_thermal_params = {
+ 	.no_hwmon = true,
+ };
+@@ -382,6 +430,7 @@ static struct thermal_zone_device_ops mlxsw_thermal_ops = {
+ 	.set_trip_temp	= mlxsw_thermal_set_trip_temp,
+ 	.get_trip_hyst	= mlxsw_thermal_get_trip_hyst,
+ 	.set_trip_hyst	= mlxsw_thermal_set_trip_hyst,
++	.get_trend	= mlxsw_thermal_trend_get,
+ };
+ 
+ static int mlxsw_thermal_module_bind(struct thermal_zone_device *tzdev,
+@@ -499,6 +548,8 @@ static int mlxsw_thermal_module_temp_get(struct thermal_zone_device *tzdev,
+ 
+ 	/* Update trip points. */
+ 	err = mlxsw_thermal_module_trips_update(dev, thermal->core, tz);
++	if (!err && temp > 0)
++		mlxsw_thermal_tz_score_update(thermal, tzdev, tz->trips, temp);
+ 
+ 	return 0;
+ }
+@@ -574,6 +625,7 @@ static struct thermal_zone_device_ops mlxsw_thermal_module_ops = {
+ 	.set_trip_temp	= mlxsw_thermal_module_trip_temp_set,
+ 	.get_trip_hyst	= mlxsw_thermal_module_trip_hyst_get,
+ 	.set_trip_hyst	= mlxsw_thermal_module_trip_hyst_set,
++	.get_trend	= mlxsw_thermal_trend_get,
+ };
+ 
+ static int mlxsw_thermal_gearbox_temp_get(struct thermal_zone_device *tzdev,
+@@ -600,6 +652,8 @@ static int mlxsw_thermal_gearbox_temp_get(struct thermal_zone_device *tzdev,
+ 		return err;
+ 
+ 	mlxsw_reg_mtmp_unpack(mtmp_pl, &temp, NULL, NULL);
++	if (temp > 0)
++		mlxsw_thermal_tz_score_update(thermal, tzdev, tz->trips, temp);
+ 
+ 	*p_temp = temp;
+ 	return 0;
+@@ -616,6 +670,7 @@ static struct thermal_zone_device_ops mlxsw_thermal_gearbox_ops = {
+ 	.set_trip_temp	= mlxsw_thermal_module_trip_temp_set,
+ 	.get_trip_hyst	= mlxsw_thermal_module_trip_hyst_get,
+ 	.set_trip_hyst	= mlxsw_thermal_module_trip_hyst_set,
++	.get_trend	= mlxsw_thermal_trend_get,
+ };
+ 
+ static int mlxsw_thermal_get_max_state(struct thermal_cooling_device *cdev,
+-- 
+2.11.0
+

--- a/patch/0060-hwmon-pmbus-core-Add-support-for-vid-mode-detecti.patch
+++ b/patch/0060-hwmon-pmbus-core-Add-support-for-vid-mode-detecti.patch
@@ -1,0 +1,386 @@
+From 482c5a7b46fd39c2df42c47f96a817c2d50b9c75 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Tue, 3 Mar 2020 14:33:59 +0200
+Subject: [hwmon v1] hwmon: (pmbus/core) Add support for vid mode detection per
+ page bases
+
+Add support for VID protocol detection per page bases, instead of
+detecting it based on PMBU_VOUT readout from page 0.
+The reason that some devices allows to configure different VID modes
+per page within the same device.
+
+Extend "vrm_version" with the type for Intel IMVP9 and AMD 6.25mV VID
+modes.
+Add calculation for those types.
+
+Add support for devices XDPE12254, XDPE12284.
+All these device support two pages.
+The below lists of VOUT_MODE command readout with their related VID
+protocols, Digital to Analog Converter steps, supported by these
+devices:
+VR12.0 mode, 5-mV DAC - 0x01;
+VR12.5 mode, 10-mV DAC - 0x02;
+IMVP9 mode, 5-mV DAC - 0x03;
+AMD mode 6.25mV - 0x10.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/hwmon/pmbus/Kconfig      |   9 +++
+ drivers/hwmon/pmbus/Makefile     |   1 +
+ drivers/hwmon/pmbus/max20751.c   |   2 +-
+ drivers/hwmon/pmbus/pmbus.c      |   5 +-
+ drivers/hwmon/pmbus/pmbus.h      |   4 +-
+ drivers/hwmon/pmbus/pmbus_core.c |  10 ++-
+ drivers/hwmon/pmbus/tps53679.c   |  44 +++++-----
+ drivers/hwmon/pmbus/xdpe12284.c  | 171 +++++++++++++++++++++++++++++++++++++++
+ 8 files changed, 219 insertions(+), 27 deletions(-)
+ create mode 100644 drivers/hwmon/pmbus/xdpe12284.c
+
+diff --git a/drivers/hwmon/pmbus/Kconfig b/drivers/hwmon/pmbus/Kconfig
+index 61938ea22208..79fd67e0c940 100644
+--- a/drivers/hwmon/pmbus/Kconfig
++++ b/drivers/hwmon/pmbus/Kconfig
+@@ -156,6 +156,15 @@ config SENSORS_UCD9200
+ 	  This driver can also be built as a module. If so, the module will
+ 	  be called ucd9200.
+ 
++config SENSORS_XDPE122
++	tristate "Infineon XDPE122 family"
++	help
++	  If you say yes here you get hardware monitoring support for Infineon
++	  XDPE12254, XDPE12284, device.
++
++	  This driver can also be built as a module. If so, the module will
++	  be called xdpe12284.
++
+ config SENSORS_ZL6100
+ 	tristate "Intersil ZL6100 and compatibles"
+ 	default n
+diff --git a/drivers/hwmon/pmbus/Makefile b/drivers/hwmon/pmbus/Makefile
+index b912fec9876d..e0fe17121afb 100644
+--- a/drivers/hwmon/pmbus/Makefile
++++ b/drivers/hwmon/pmbus/Makefile
+@@ -16,4 +16,5 @@ obj-$(CONFIG_SENSORS_TPS40422)	+= tps40422.o
+ obj-$(CONFIG_SENSORS_TPS53679)	+= tps53679.o
+ obj-$(CONFIG_SENSORS_UCD9000)	+= ucd9000.o
+ obj-$(CONFIG_SENSORS_UCD9200)	+= ucd9200.o
++obj-$(CONFIG_SENSORS_XDPE122)	+= xdpe12284.o
+ obj-$(CONFIG_SENSORS_ZL6100)	+= zl6100.o
+diff --git a/drivers/hwmon/pmbus/max20751.c b/drivers/hwmon/pmbus/max20751.c
+index ab74aeae8cf2..394c662c811b 100644
+--- a/drivers/hwmon/pmbus/max20751.c
++++ b/drivers/hwmon/pmbus/max20751.c
+@@ -25,7 +25,7 @@ static struct pmbus_driver_info max20751_info = {
+ 	.pages = 1,
+ 	.format[PSC_VOLTAGE_IN] = linear,
+ 	.format[PSC_VOLTAGE_OUT] = vid,
+-	.vrm_version = vr12,
++	.vrm_version[0] = vr12,
+ 	.format[PSC_TEMPERATURE] = linear,
+ 	.format[PSC_CURRENT_OUT] = linear,
+ 	.format[PSC_POWER] = linear,
+diff --git a/drivers/hwmon/pmbus/pmbus.c b/drivers/hwmon/pmbus/pmbus.c
+index 44ca8a94873d..ad360a88a53a 100644
+--- a/drivers/hwmon/pmbus/pmbus.c
++++ b/drivers/hwmon/pmbus/pmbus.c
+@@ -121,7 +121,7 @@ static int pmbus_identify(struct i2c_client *client,
+ 	}
+ 
+ 	if (pmbus_check_byte_register(client, 0, PMBUS_VOUT_MODE)) {
+-		int vout_mode;
++		int vout_mode, i;
+ 
+ 		vout_mode = pmbus_read_byte_data(client, 0, PMBUS_VOUT_MODE);
+ 		if (vout_mode >= 0 && vout_mode != 0xff) {
+@@ -130,7 +130,8 @@ static int pmbus_identify(struct i2c_client *client,
+ 				break;
+ 			case 1:
+ 				info->format[PSC_VOLTAGE_OUT] = vid;
+-				info->vrm_version = vr11;
++				for (i = 0; i < info->pages; i++)
++					info->vrm_version[i] = vr11;
+ 				break;
+ 			case 2:
+ 				info->format[PSC_VOLTAGE_OUT] = direct;
+diff --git a/drivers/hwmon/pmbus/pmbus.h b/drivers/hwmon/pmbus/pmbus.h
+index 4efa2bd4f6d8..881156491581 100644
+--- a/drivers/hwmon/pmbus/pmbus.h
++++ b/drivers/hwmon/pmbus/pmbus.h
+@@ -341,12 +341,12 @@ enum pmbus_sensor_classes {
+ #define PMBUS_HAVE_STATUS_VMON	BIT(19)
+ 
+ enum pmbus_data_format { linear = 0, direct, vid };
+-enum vrm_version { vr11 = 0, vr12, vr13 };
++enum vrm_version { vr11 = 0, vr12, vr13, imvp9, amd625mv };
+ 
+ struct pmbus_driver_info {
+ 	int pages;		/* Total number of pages */
+ 	enum pmbus_data_format format[PSC_NUM_CLASSES];
+-	enum vrm_version vrm_version;
++	enum vrm_version vrm_version[PMBUS_PAGES]; /* vrm version per page */
+ 	/*
+ 	 * Support one set of coefficients for each sensor type
+ 	 * Used for chips providing data in direct mode.
+diff --git a/drivers/hwmon/pmbus/pmbus_core.c b/drivers/hwmon/pmbus/pmbus_core.c
+index 682b01624908..764a28105831 100644
+--- a/drivers/hwmon/pmbus/pmbus_core.c
++++ b/drivers/hwmon/pmbus/pmbus_core.c
+@@ -522,7 +522,7 @@ static long pmbus_reg2data_vid(struct pmbus_data *data,
+ 	long val = sensor->data;
+ 	long rv = 0;
+ 
+-	switch (data->info->vrm_version) {
++	switch (data->info->vrm_version[sensor->page]) {
+ 	case vr11:
+ 		if (val >= 0x02 && val <= 0xb2)
+ 			rv = DIV_ROUND_CLOSEST(160000 - (val - 2) * 625, 100);
+@@ -535,6 +535,14 @@ static long pmbus_reg2data_vid(struct pmbus_data *data,
+ 		if (val >= 0x01)
+ 			rv = 500 + (val - 1) * 10;
+ 		break;
++	case imvp9:
++		if (val >= 0x01)
++			rv = 200 + (val - 1) * 10;
++		break;
++	case amd625mv:
++		if (val >= 0x0 && val <= 0xd8)
++			rv = DIV_ROUND_CLOSEST(155000 - val * 625, 100);
++		break;
+ 	}
+ 	return rv;
+ }
+diff --git a/drivers/hwmon/pmbus/tps53679.c b/drivers/hwmon/pmbus/tps53679.c
+index 45eacc504e2f..28d3de029b91 100644
+--- a/drivers/hwmon/pmbus/tps53679.c
++++ b/drivers/hwmon/pmbus/tps53679.c
+@@ -33,27 +33,29 @@ static int tps53679_identify(struct i2c_client *client,
+ 			     struct pmbus_driver_info *info)
+ {
+ 	u8 vout_params;
+-	int ret;
+-
+-	/* Read the register with VOUT scaling value.*/
+-	ret = pmbus_read_byte_data(client, 0, PMBUS_VOUT_MODE);
+-	if (ret < 0)
+-		return ret;
+-
+-	vout_params = ret & GENMASK(4, 0);
+-
+-	switch (vout_params) {
+-	case TPS53679_PROT_VR13_10MV:
+-	case TPS53679_PROT_VR12_5_10MV:
+-		info->vrm_version = vr13;
+-		break;
+-	case TPS53679_PROT_VR13_5MV:
+-	case TPS53679_PROT_VR12_5MV:
+-	case TPS53679_PROT_IMVP8_5MV:
+-		info->vrm_version = vr12;
+-		break;
+-	default:
+-		return -EINVAL;
++	int i, ret;
++
++	for (i = 0; i < TPS53679_PAGE_NUM; i++) {
++		/* Read the register with VOUT scaling value.*/
++		ret = pmbus_read_byte_data(client, i, PMBUS_VOUT_MODE);
++		if (ret < 0)
++			return ret;
++
++		vout_params = ret & GENMASK(4, 0);
++
++		switch (vout_params) {
++		case TPS53679_PROT_VR13_10MV:
++		case TPS53679_PROT_VR12_5_10MV:
++			info->vrm_version[i] = vr13;
++			break;
++		case TPS53679_PROT_VR13_5MV:
++		case TPS53679_PROT_VR12_5MV:
++		case TPS53679_PROT_IMVP8_5MV:
++			info->vrm_version[i] = vr12;
++			break;
++		default:
++			return -EINVAL;
++		}
+ 	}
+ 
+ 	return 0;
+diff --git a/drivers/hwmon/pmbus/xdpe12284.c b/drivers/hwmon/pmbus/xdpe12284.c
+new file mode 100644
+index 000000000000..660556b89e9f
+--- /dev/null
++++ b/drivers/hwmon/pmbus/xdpe12284.c
+@@ -0,0 +1,171 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Hardware monitoring driver for Infineon Multi-phase Digital VR Controllers
++ *
++ * Copyright (c) 2020 Mellanox Technologies. All rights reserved.
++ */
++
++#include <linux/err.h>
++#include <linux/i2c.h>
++#include <linux/init.h>
++#include <linux/kernel.h>
++#include <linux/module.h>
++#include "pmbus.h"
++
++#define XDPE122_PROT_VR12_5MV		0x01 /* VR12.0 mode, 5-mV DAC */
++#define XDPE122_PROT_VR12_5_10MV	0x02 /* VR12.5 mode, 10-mV DAC */
++#define XDPE122_PROT_IMVP9_10MV		0x03 /* IMVP9 mode, 10-mV DAC */
++#define XDPE122_AMD_625MV		0x10 /* AMD mode 6.25mV */
++#define XDPE122_PAGE_NUM		2
++
++static int xdpe122_read_word_data(struct i2c_client *client, int page, int reg)
++{
++	const struct pmbus_driver_info *info = pmbus_get_driver_info(client);
++	long val;
++	s16 exponent;
++	s32 mantissa;
++	int ret;
++
++	switch (reg) {
++	case PMBUS_VOUT_OV_FAULT_LIMIT:
++	case PMBUS_VOUT_UV_FAULT_LIMIT:
++		ret = pmbus_read_word_data(client, page, reg);
++		if (ret < 0)
++			return ret;
++
++		/* Convert register value to LINEAR11 data. */
++		exponent = ((s16)ret) >> 11;
++		mantissa = ((s16)((ret & GENMASK(10, 0)) << 5)) >> 5;
++		val = mantissa * 1000L;
++		if (exponent >= 0)
++			val <<= exponent;
++		else
++			val >>= -exponent;
++
++		/* Convert data to VID register. */
++		switch (info->vrm_version[page]) {
++		case vr13:
++			if (val >= 500)
++				return 1 + DIV_ROUND_CLOSEST(val - 500, 10);
++			return 0;
++		case vr12:
++			if (val >= 250)
++				return 1 + DIV_ROUND_CLOSEST(val - 250, 5);
++			return 0;
++		case imvp9:
++			if (val >= 200)
++				return 1 + DIV_ROUND_CLOSEST(val - 200, 10);
++			return 0;
++		case amd625mv:
++			if (val >= 200 && val <= 1550)
++				return DIV_ROUND_CLOSEST((1550 - val) * 100,
++							 625);
++			return 0;
++		default:
++			return -EINVAL;
++		}
++	default:
++		return -ENODATA;
++	}
++
++	return 0;
++}
++
++static int xdpe122_identify(struct i2c_client *client,
++			    struct pmbus_driver_info *info)
++{
++	u8 vout_params;
++	int i, ret;
++
++	for (i = 0; i < XDPE122_PAGE_NUM; i++) {
++		/* Read the register with VOUT scaling value.*/
++		ret = pmbus_read_byte_data(client, i, PMBUS_VOUT_MODE);
++		if (ret < 0)
++			return ret;
++
++		vout_params = ret & GENMASK(4, 0);
++
++		switch (vout_params) {
++		case XDPE122_PROT_VR12_5_10MV:
++			info->vrm_version[i] = vr13;
++			break;
++		case XDPE122_PROT_VR12_5MV:
++			info->vrm_version[i] = vr12;
++			break;
++		case XDPE122_PROT_IMVP9_10MV:
++			info->vrm_version[i] = imvp9;
++			break;
++		case XDPE122_AMD_625MV:
++			info->vrm_version[i] = amd625mv;
++			break;
++		default:
++			return -EINVAL;
++		}
++	}
++
++	return 0;
++}
++
++static struct pmbus_driver_info xdpe122_info = {
++	.pages = XDPE122_PAGE_NUM,
++	.format[PSC_VOLTAGE_IN] = linear,
++	.format[PSC_VOLTAGE_OUT] = vid,
++	.format[PSC_TEMPERATURE] = linear,
++	.format[PSC_CURRENT_IN] = linear,
++	.format[PSC_CURRENT_OUT] = linear,
++	.format[PSC_POWER] = linear,
++	.func[0] = PMBUS_HAVE_VIN | PMBUS_HAVE_VOUT | PMBUS_HAVE_STATUS_VOUT |
++		PMBUS_HAVE_IIN | PMBUS_HAVE_IOUT | PMBUS_HAVE_STATUS_IOUT |
++		PMBUS_HAVE_TEMP | PMBUS_HAVE_STATUS_TEMP |
++		PMBUS_HAVE_POUT | PMBUS_HAVE_PIN | PMBUS_HAVE_STATUS_INPUT,
++	.func[1] = PMBUS_HAVE_VIN | PMBUS_HAVE_VOUT | PMBUS_HAVE_STATUS_VOUT |
++		PMBUS_HAVE_IIN | PMBUS_HAVE_IOUT | PMBUS_HAVE_STATUS_IOUT |
++		PMBUS_HAVE_TEMP | PMBUS_HAVE_STATUS_TEMP |
++		PMBUS_HAVE_POUT | PMBUS_HAVE_PIN | PMBUS_HAVE_STATUS_INPUT,
++	.identify = xdpe122_identify,
++	.read_word_data = xdpe122_read_word_data,
++};
++
++static int xdpe122_probe(struct i2c_client *client,
++			 const struct i2c_device_id *id)
++{
++	struct pmbus_driver_info *info;
++
++	info = devm_kmemdup(&client->dev, &xdpe122_info, sizeof(*info),
++			    GFP_KERNEL);
++	if (!info)
++		return -ENOMEM;
++
++	return pmbus_do_probe(client, id, info);
++}
++
++static const struct i2c_device_id xdpe122_id[] = {
++	{"xdpe12254", 0},
++	{"xdpe12284", 0},
++	{}
++};
++
++MODULE_DEVICE_TABLE(i2c, xdpe122_id);
++
++static const struct of_device_id __maybe_unused xdpe122_of_match[] = {
++	{.compatible = "infineon,xdpe12254"},
++	{.compatible = "infineon,xdpe12284"},
++	{}
++};
++MODULE_DEVICE_TABLE(of, xdpe122_of_match);
++
++static struct i2c_driver xdpe122_driver = {
++	.driver = {
++		.name = "xdpe12284",
++		.of_match_table = of_match_ptr(xdpe122_of_match),
++	},
++	.probe = xdpe122_probe,
++	.remove = pmbus_do_remove,
++	.id_table = xdpe122_id,
++};
++
++module_i2c_driver(xdpe122_driver);
++
++MODULE_AUTHOR("Vadim Pasternak <vadimp@mellanox.com>");
++MODULE_DESCRIPTION("PMBus driver for Infineon XDPE122 family");
++MODULE_LICENSE("GPL");
+-- 
+2.11.0
+

--- a/patch/0061-i2c-busses-i2c-mlxcpld-Increase-transaction-pooli.patch
+++ b/patch/0061-i2c-busses-i2c-mlxcpld-Increase-transaction-pooli.patch
@@ -1,0 +1,31 @@
+From 10301ce5d3375b4a088710e3ce8ecc6f4acc6ed7 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Thu, 5 Mar 2020 13:09:06 +0200
+Subject: [hwmon v1] i2c: busses: i2c-mlxcpld: Increase transaction pooling
+ time
+
+i2c-mlxcpld polling time from 200 to 600 usec due to some
+problematic power supply units, which cannot work with
+such frequency.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/i2c/busses/i2c-mlxcpld.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/i2c/busses/i2c-mlxcpld.c b/drivers/i2c/busses/i2c-mlxcpld.c
+index 41b57027e348..6da4b58eee4f 100644
+--- a/drivers/i2c/busses/i2c-mlxcpld.c
++++ b/drivers/i2c/busses/i2c-mlxcpld.c
+@@ -51,7 +51,7 @@
+ #define MLXCPLD_I2C_MAX_ADDR_LEN	4
+ #define MLXCPLD_I2C_RETR_NUM		2
+ #define MLXCPLD_I2C_XFER_TO		500000 /* usec */
+-#define MLXCPLD_I2C_POLL_TIME		200   /* usec */
++#define MLXCPLD_I2C_POLL_TIME		400   /* usec */
+ 
+ /* LPC I2C registers */
+ #define MLXCPLD_LPCI2C_CPBLTY_REG	0x0
+-- 
+2.11.0
+

--- a/patch/0062-platform-mellanox-mlxreg-hotplug-Use-capability-r.patch
+++ b/patch/0062-platform-mellanox-mlxreg-hotplug-Use-capability-r.patch
@@ -1,0 +1,73 @@
+From af50fedeeaa767a0c7c3a9cf399fe23314adc609 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Thu, 12 Mar 2020 23:51:41 +0200
+Subject: [platform-next v1 1/2] platform/mellanox: mlxreg-hotplug: Use
+ capability register for attribute creation
+
+Create the 'sysfs' attributes according to configuration provided
+through the capability register, which purpose is to indicate the
+actual number of the components within the particular group.
+Such components could be, for example the FAN or power supply units.
+The motivation is to avoid adding a new code in the future in order to
+distinct between the systems types supported different number of the
+components like power supplies, FANs, ASICs, line cards.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/platform/mellanox/mlxreg-hotplug.c | 23 +++++++++++++++++++----
+ 1 file changed, 19 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlxreg-hotplug.c b/drivers/platform/mellanox/mlxreg-hotplug.c
+index 77be37a1fbcf..c21754821789 100644
+--- a/drivers/platform/mellanox/mlxreg-hotplug.c
++++ b/drivers/platform/mellanox/mlxreg-hotplug.c
+@@ -196,17 +196,29 @@ static int mlxreg_hotplug_attr_init(struct mlxreg_hotplug_priv_data *priv)
+ 	struct mlxreg_core_hotplug_platform_data *pdata;
+ 	struct mlxreg_core_item *item;
+ 	struct mlxreg_core_data *data;
+-	int num_attrs = 0, id = 0, i, j;
++	u32 regval;
++	int num_attrs = 0, id = 0, i, j, k, ret;
+ 
+ 	pdata = dev_get_platdata(&priv->pdev->dev);
+ 	item = pdata->items;
+ 
+ 	/* Go over all kinds of items - psu, pwr, fan. */
+ 	for (i = 0; i < pdata->counter; i++, item++) {
+-		num_attrs += item->count;
+ 		data = item->data;
+ 		/* Go over all units within the item. */
+-		for (j = 0; j < item->count; j++, data++, id++) {
++		for (j = 0, k = 0; j < item->count; j++, data++) {
++			if (data->capability) {
++				/*
++				 * Read capability register and skip non
++				 * relevant attributes.
++				 */
++				ret = regmap_read(priv->regmap,
++						  data->capability, &regval);
++				if (ret)
++					return ret;
++				if (!(regval & data->bit))
++					continue;
++			}
+ 			PRIV_ATTR(id) = &PRIV_DEV_ATTR(id).dev_attr.attr;
+ 			PRIV_ATTR(id)->name = devm_kasprintf(&priv->pdev->dev,
+ 							     GFP_KERNEL,
+@@ -224,9 +236,12 @@ static int mlxreg_hotplug_attr_init(struct mlxreg_hotplug_priv_data *priv)
+ 			PRIV_DEV_ATTR(id).dev_attr.show =
+ 						mlxreg_hotplug_attr_show;
+ 			PRIV_DEV_ATTR(id).nr = i;
+-			PRIV_DEV_ATTR(id).index = j;
++			PRIV_DEV_ATTR(id).index = k;
+ 			sysfs_attr_init(&PRIV_DEV_ATTR(id).dev_attr.attr);
++			id++;
++			k++;
+ 		}
++		num_attrs += k;
+ 	}
+ 
+ 	priv->group.attrs = devm_kcalloc(&priv->pdev->dev,
+-- 
+2.11.0
+

--- a/patch/0063-platform-mellanox-mlxreg-io-Add-support-for-compl.patch
+++ b/patch/0063-platform-mellanox-mlxreg-io-Add-support-for-compl.patch
@@ -1,0 +1,256 @@
+From e74853715ed50660960ee7891e1979c685ab2fde Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Fri, 13 Mar 2020 00:15:54 +0200
+Subject: [platform-next v1 2/2] platform/mellanox: mlxreg-io: Add support for
+ complex attributes
+
+Add support for attributes composed from few registers.
+Such attributes could occupy from 2 to 4 sequential registers.
+This is not the case for double word size register space, for word size
+register space complex attribute can occupy up to two register, for
+byte size - up to four. These attributes can carry, for example, CPLD
+or FPGA versioning, power consuming info, etcetera.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/platform/mellanox/mlxreg-io.c | 79 ++++++++++++++++++++++++++++++-----
+ drivers/platform/x86/mlx-platform.c   | 72 +++++++++++++++++++++++++++++++
+ 2 files changed, 141 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlxreg-io.c b/drivers/platform/mellanox/mlxreg-io.c
+index acfaf64ffde6..b8b8300928dd 100644
+--- a/drivers/platform/mellanox/mlxreg-io.c
++++ b/drivers/platform/mellanox/mlxreg-io.c
+@@ -19,6 +19,13 @@
+ /* Attribute parameters. */
+ #define MLXREG_IO_ATT_SIZE	10
+ #define MLXREG_IO_ATT_NUM	48
++#define MLXREG_IO_REGVAL_ARR	4
++#define MLXREG_IO_REG_8BIT	GENMASK(7, 0)
++#define MLXREG_IO_REG_16BIT	GENMASK(15, 0)
++#define MLXREG_IO_REG_24BIT	GENMASK(23, 0)
++#define MLXREG_IO_REG_32BIT	GENMASK(31, 0)
++#define MLXREG_IO_REG_BYTE	8
++#define MLXREG_IO_REG_WORD	16
+ 
+ /**
+  * struct mlxreg_io_priv_data - driver's private data:
+@@ -45,21 +52,23 @@ static int
+ mlxreg_io_get_reg(void *regmap, struct mlxreg_core_data *data, u32 in_val,
+ 		  bool rw_flag, u32 *regval)
+ {
+-	int ret;
++	u32 val;
++	int regnum, len, mask, i, ret;
+ 
+ 	ret = regmap_read(regmap, data->reg, regval);
+ 	if (ret)
+ 		goto access_error;
+-
+ 	/*
+-	 * There are three kinds of attributes: single bit, full register's
+-	 * bits and bit sequence. For the first kind field mask indicates which
+-	 * bits are not related and field bit is set zero. For the second kind
+-	 * field mask is set to zero and field bit is set with all bits one.
+-	 * No special handling for such kind of attributes - pass value as is.
+-	 * For the third kind, field mask indicates which bits are related and
+-	 * field bit is set to the first bit number (from 1 to 32) is the bit
+-	 * sequence.
++	 * There are four kinds of attributes: single bit, full register's
++	 * bits, bit sequence, bits in few registers For the first kind field
++	 * mask indicates which bits are not related and field bit is set zero.
++	 * For the second kind field mask is set to zero and field bit is set
++	 * with all bits one. No special handling for such kind of attributes -
++	 * pass value as is. For the third kind, field mask indicates which
++	 * bits are related and field bit is set to the first bit number (from
++	 * 1 to 32) is the bit sequence. For the fourth mask - the number of
++	 * registers which should be written for attribute are set according
++	 * to 'data->bit' field.
+ 	 */
+ 	if (!data->bit) {
+ 		/* Single bit. */
+@@ -83,6 +92,56 @@ mlxreg_io_get_reg(void *regmap, struct mlxreg_core_data *data, u32 in_val,
+ 			/* Clear relevant bits and set them to new value. */
+ 			*regval = (*regval & ~data->mask) | in_val;
+ 		}
++	} else {
++		/*
++		 * Some attributes could occupied few registers in case regmap
++		 * bit size is 8 or 16. Maximum register for such case is
++		 * respectively 0xff or 0xffff. Not relevant for the case, when
++		 * regmap bit size is 32 and maximum registers 0xffffffff.
++		 */
++		mask = regmap_get_max_register(regmap);
++		if (mask < 0)
++			goto access_error;
++
++		/*
++		 * Get register bit length and the number of registers from
++		 * wich this attribute is composed. Attribute can be located
++		 * in 1, 2, 3 or 4 registers.
++		 */
++		switch (mask) {
++		case MLXREG_IO_REG_8BIT:
++			if (data->bit > MLXREG_IO_REG_24BIT)
++				regnum = 4;
++			else if (data->bit > MLXREG_IO_REG_16BIT)
++				regnum = 3;
++			else if (data->bit > MLXREG_IO_REG_8BIT)
++				regnum = 2;
++			else
++				return ret;
++			len = MLXREG_IO_REG_BYTE;
++			break;
++		case MLXREG_IO_REG_16BIT:
++			if (data->bit > MLXREG_IO_REG_16BIT)
++				regnum = 2;
++			else
++				return ret;
++			len = MLXREG_IO_REG_WORD;
++			break;
++		case MLXREG_IO_REG_32BIT:
++			return ret;
++		default:
++			return -EINVAL;
++		}
++
++		/* Compose attribute from 'regnum' registers. */
++		for (i = 1; i < regnum; i++) {
++			ret = regmap_read(regmap, data->reg + i, &val);
++			if (ret)
++				goto access_error;
++
++			*regval |= rol32(val, len * i);
++		}
++		*regval = le32_to_cpu(*regval & mask);
+ 	}
+ 
+ access_error:
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index c27548fd386a..a916a1d7ce2d 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -26,6 +26,10 @@
+ #define MLXPLAT_CPLD_LPC_REG_CPLD2_VER_OFFSET	0x01
+ #define MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET	0x02
+ #define MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET	0x03
++#define MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET	0x04
++#define MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET	0x06
++#define MLXPLAT_CPLD_LPC_REG_CPLD3_PN_OFFSET	0x08
++#define MLXPLAT_CPLD_LPC_REG_CPLD4_PN_OFFSET	0x0a
+ #define MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET	0x1d
+ #define MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET	0x1e
+ #define MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET	0x1f
+@@ -72,6 +76,10 @@
+ #define MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET	0xd1
+ #define MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET	0xd2
+ #define MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET	0xd3
++#define MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET	0xde
++#define MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET	0xdf
++#define MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET	0xe0
++#define MLXPLAT_CPLD_LPC_REG_CPLD4_MVER_OFFSET	0xe1
+ #define MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET	0xe2
+ #define MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET	0xe3
+ #define MLXPLAT_CPLD_LPC_REG_TACHO1_OFFSET	0xe4
+@@ -1528,6 +1536,54 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mode = 0444,
+ 	},
+ 	{
++		.label = "cpld1_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld2_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld3_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD3_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld4_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD4_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld1_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld2_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld3_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld4_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD4_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
+ 		.label = "reset_long_pb",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(0),
+@@ -2006,6 +2062,10 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD3_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD4_PN_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET:
+@@ -2051,6 +2111,10 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD4_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_TACHO1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_TACHO2_OFFSET:
+@@ -2085,6 +2149,10 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD3_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD4_PN_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET:
+@@ -2122,6 +2190,10 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_WD2_TLEFT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD4_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_TACHO1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_TACHO2_OFFSET:
+-- 
+2.11.0
+

--- a/patch/0064-Add-config-for-sensor-xdpe122-and-modify-mlx_wdt-.patch
+++ b/patch/0064-Add-config-for-sensor-xdpe122-and-modify-mlx_wdt-.patch
@@ -1,0 +1,89 @@
+From 90ddafe594f825e72fcdf4294f60e73ba7a689f9 Mon Sep 17 00:00:00 2001
+From: Stephen Sun <stephens@mellanox.com>
+Date: Wed, 25 Mar 2020 15:07:34 +0000
+Subject: [PATCH] Add config for sensor xdpe122 and modify mlx_wdt to m
+Add the following options to kernel config file:
+CONFIG_SENSORS_XDPE122=m Modify the following
+options to kernel config file:
+CONFIG_MLX_WDT=y => CONFIG_MLX_WDT=m
+
+Signed-off-by: Stephen Sun <stephens@mellanox.com>
+---
+ debian/build/build_amd64_none_amd64/.config | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/debian/build/build_amd64_none_amd64/.config b/debian/build/build_amd64_none_amd64/.config
+index 6c4c6443..6ae593b6 100644
+--- a/debian/build/build_amd64_none_amd64/.config
++++ b/debian/build/build_amd64_none_amd64/.config
+@@ -707,7 +707,6 @@ CONFIG_ACPI_EXTLOG=y
+ # CONFIG_PMIC_OPREGION is not set
+ # CONFIG_ACPI_CONFIGFS is not set
+ CONFIG_SFI=y
+-CONFIG_SENSORS_MLXREG_FAN=m
+ 
+ #
+ # CPU Frequency scaling
+@@ -1453,6 +1452,7 @@ CONFIG_NET_ACT_POLICE=m
+ CONFIG_NET_ACT_GACT=m
+ CONFIG_GACT_PROB=y
+ CONFIG_NET_ACT_MIRRED=m
++CONFIG_NET_ACT_SAMPLE=m
+ CONFIG_NET_ACT_IPT=m
+ CONFIG_NET_ACT_NAT=m
+ CONFIG_NET_ACT_PEDIT=m
+@@ -1761,6 +1761,7 @@ CONFIG_NFC_PN533_USB=m
+ # CONFIG_NFC_PN533_I2C is not set
+ # CONFIG_NFC_MICROREAD_MEI is not set
+ # CONFIG_NFC_ST95HF is not set
++CONFIG_PSAMPLE=m
+ CONFIG_LWTUNNEL=y
+ CONFIG_DST_CACHE=y
+ CONFIG_NET_DEVLINK=m
+@@ -3925,6 +3926,7 @@ CONFIG_SENSORS_MAX6620=m
+ CONFIG_SENSORS_MAX6697=m
+ CONFIG_SENSORS_MAX31790=m
+ # CONFIG_SENSORS_MCP3021 is not set
++CONFIG_SENSORS_MLXREG_FAN=m
+ CONFIG_SENSORS_MENF21BMC_HWMON=m
+ CONFIG_SENSORS_ADCXX=m
+ CONFIG_SENSORS_LM63=m
+@@ -3966,8 +3968,9 @@ CONFIG_SENSORS_DNI_DPS460=m
+ CONFIG_SENSORS_TPS53679=m
+ CONFIG_SENSORS_UCD9000=m
+ CONFIG_SENSORS_UCD9200=m
+-CONFIG_SENSORS_DPS1900=m
++CONFIG_SENSORS_XDPE122=m
+ # CONFIG_SENSORS_ZL6100 is not set
++CONFIG_SENSORS_DPS1900=m
+ # CONFIG_SENSORS_SHT15 is not set
+ CONFIG_SENSORS_SHT21=m
+ # CONFIG_SENSORS_SHT3x is not set
+@@ -4057,6 +4060,7 @@ CONFIG_MENF21BMC_WATCHDOG=m
+ # CONFIG_WDAT_WDT is not set
+ # CONFIG_XILINX_WATCHDOG is not set
+ # CONFIG_ZIIRAVE_WATCHDOG is not set
++CONFIG_MLX_WDT=m
+ # CONFIG_CADENCE_WATCHDOG is not set
+ # CONFIG_DW_WATCHDOG is not set
+ # CONFIG_MAX63XX_WATCHDOG is not set
+@@ -4097,7 +4101,6 @@ CONFIG_SBC_EPX_C3_WATCHDOG=m
+ # CONFIG_NI903X_WDT is not set
+ # CONFIG_MEN_A21_WDT is not set
+ CONFIG_XEN_WDT=m
+-CONFIG_MLX_WDT=y
+ 
+ #
+ # PCI-based Watchdog Cards
+@@ -6139,7 +6142,7 @@ CONFIG_INTEL_MIC_X100_DMA=m
+ # CONFIG_QCOM_HIDMA is not set
+ CONFIG_DW_DMAC_CORE=m
+ CONFIG_DW_DMAC=m
+-# CONFIG_DW_DMAC_PCI is not set
++CONFIG_DW_DMAC_PCI=m
+ CONFIG_HSU_DMA=y
+ 
+ #
+-- 
+2.11.0
+

--- a/patch/0065-mlxsw-qsfp_sysfs-Remove-obsolete-code-for-QSFP-EEPRO.patch
+++ b/patch/0065-mlxsw-qsfp_sysfs-Remove-obsolete-code-for-QSFP-EEPRO.patch
@@ -1,0 +1,411 @@
+From 0deb2ef6a0ff3ba73dceb9361cd2c866c195dc7f Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Tue, 31 Mar 2020 22:36:17 +0300
+Subject: [mlxsw qsfp] mlxsw: qsfp_sysfs: Remove obsolete code for QSFP EEPROM
+ reading
+
+Remove QSFP EEPROM attribures from 'sysfs'.
+This code is obsoleted.
+
+Make de-init order symmetrical with init.
+    .
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core.c       |   4 +-
+ drivers/net/ethernet/mellanox/mlxsw/qsfp_sysfs.c | 299 +----------------------
+ 2 files changed, 13 insertions(+), 290 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core.c b/drivers/net/ethernet/mellanox/mlxsw/core.c
+index a127e0b01e4e..0583c7b328a5 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core.c
+@@ -1051,11 +1051,11 @@ void mlxsw_core_bus_device_unregister(struct mlxsw_core *mlxsw_core,
+ 			return;
+ 	}
+ 
+-	if (mlxsw_core->driver->fini)
+-		mlxsw_core->driver->fini(mlxsw_core);
+ 	mlxsw_qsfp_fini(mlxsw_core->qsfp);
+ 	mlxsw_thermal_fini(mlxsw_core->thermal);
+ 	mlxsw_hwmon_fini(mlxsw_core->hwmon);
++	if (mlxsw_core->driver->fini)
++		mlxsw_core->driver->fini(mlxsw_core);
+ 	if (!reload)
+ 		devlink_unregister(devlink);
+ 	mlxsw_emad_fini(mlxsw_core);
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/qsfp_sysfs.c b/drivers/net/ethernet/mellanox/mlxsw/qsfp_sysfs.c
+index 49563a703d75..931dbd58e4bd 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/qsfp_sysfs.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/qsfp_sysfs.c
+@@ -41,171 +41,18 @@
+ 
+ #include "core.h"
+ 
+-#define MLXSW_QSFP_I2C_ADDR		0x50
+-#define MLXSW_QSFP_PAGE_NUM		5
+-#define MLXSW_QSFP_PAGE_SIZE		128
+-#define MLXSW_QSFP_SUB_PAGE_NUM		3
+-#define MLXSW_QSFP_SUB_PAGE_SIZE	48
+-#define MLXSW_QSFP_LAST_SUB_PAGE_SIZE	32
+-#define MLXSW_QSFP_MAX_NUM		128
+-#define MLXSW_QSFP_MIN_REQ_LEN		4
+-#define MLXSW_QSFP_STATUS_VALID_TIME	(120 * HZ)
+-#define MLXSW_QSFP_MAX_CPLD_NUM		3
+-#define MLXSW_QSFP_MIN_CPLD_NUM		1
++#define MLXSW_QSFP_MAX_CPLD_NUM	3
++#define MLXSW_QSFP_MIN_CPLD_NUM	1
+ 
+-static const u8 mlxsw_qsfp_page_number[] = { 0xa0, 0x00, 0x01, 0x02, 0x03 };
+-static const u16 mlxsw_qsfp_page_shift[] = { 0x00, 0x80, 0x80, 0x80, 0x80 };
+-
+-/**
+- * Mellanox device Management Cable Info Access Register buffer for reading
+- * QSFP EEPROM info is limited by 48 bytes. In case full page is to be read
+- * (128 bytes), such request will be implemented by three transactions of size
+- * 48, 48, 32.
+- */
+-static const u16 mlxsw_qsfp_sub_page_size[] = {
+-	MLXSW_QSFP_SUB_PAGE_SIZE,
+-	MLXSW_QSFP_SUB_PAGE_SIZE,
+-	MLXSW_QSFP_LAST_SUB_PAGE_SIZE
+-};
+-
+-struct mlxsw_qsfp_module {
+-	unsigned long last_updated;
+-	u8 cache_status;
+-};
++static int mlxsw_qsfp_cpld_num = MLXSW_QSFP_MIN_CPLD_NUM;
+ 
+ struct mlxsw_qsfp {
+ 	struct mlxsw_core *core;
+ 	const struct mlxsw_bus_info *bus_info;
+-	struct attribute *attrs[MLXSW_QSFP_MAX_NUM + 1];
+-	struct device_attribute *dev_attrs;
+-	struct bin_attribute *eeprom;
+-	struct bin_attribute **eeprom_attr_list;
+-	struct mlxsw_qsfp_module modules[MLXSW_QSFP_MAX_NUM];
+-	u8 module_ind[MLXSW_QSFP_MAX_NUM];
+-	u8 module_count;
+ 	struct attribute *cpld_attrs[MLXSW_QSFP_MAX_CPLD_NUM + 1];
+ 	struct device_attribute *cpld_dev_attrs;
+ };
+ 
+-static int mlxsw_qsfp_cpld_num = MLXSW_QSFP_MIN_CPLD_NUM;
+-static int mlxsw_qsfp_num = MLXSW_QSFP_MAX_NUM / 2;
+-
+-static int
+-mlxsw_qsfp_query_module_eeprom(struct mlxsw_qsfp *mlxsw_qsfp, u8 index,
+-			       loff_t off, size_t count, int page, char *buf)
+-{
+-	char eeprom_tmp[MLXSW_QSFP_PAGE_SIZE];
+-	char mcia_pl[MLXSW_REG_MCIA_LEN];
+-	int status;
+-	int err;
+-
+-	mlxsw_reg_mcia_pack(mcia_pl, index, 0, page, off, count,
+-			    MLXSW_QSFP_I2C_ADDR);
+-
+-	err = mlxsw_reg_query(mlxsw_qsfp->core, MLXSW_REG(mcia), mcia_pl);
+-	if (err)
+-		return err;
+-
+-	status = mlxsw_reg_mcia_status_get(mcia_pl);
+-	if (status)
+-		return -EIO;
+-
+-	mlxsw_reg_mcia_eeprom_memcpy_from(mcia_pl, eeprom_tmp);
+-	memcpy(buf, eeprom_tmp, count);
+-
+-	return 0;
+-}
+-
+-static int
+-mlxsw_qsfp_get_module_eeprom(struct mlxsw_qsfp *mlxsw_qsfp, u8 index,
+-			     char *buf, loff_t off, size_t count)
+-{
+-	int page_ind, page, page_off, subpage, offset, size, res = 0;
+-	int err;
+-
+-	if (!count)
+-		return -EINVAL;
+-
+-	memset(buf, 0, count);
+-	size = count;
+-	while (res < count) {
+-		page_ind = off / MLXSW_QSFP_PAGE_SIZE;
+-		page_off = off % MLXSW_QSFP_PAGE_SIZE;
+-		page = mlxsw_qsfp_page_number[page_ind];
+-		offset = mlxsw_qsfp_page_shift[page_ind] + page_off;
+-		subpage = page_off / MLXSW_QSFP_SUB_PAGE_SIZE;
+-		size = min_t(u16, size, mlxsw_qsfp_sub_page_size[subpage]);
+-		err = mlxsw_qsfp_query_module_eeprom(mlxsw_qsfp, index, offset,
+-						     size, page, buf + res);
+-		if (err) {
+-			dev_err(mlxsw_qsfp->bus_info->dev, "Eeprom query failed\n");
+-			return err;
+-		}
+-		off += size;
+-		res += size;
+-		size = count - size;
+-	}
+-
+-	return res;
+-}
+-
+-static ssize_t mlxsw_qsfp_bin_read(struct file *filp, struct kobject *kobj,
+-				   struct bin_attribute *attr, char *buf,
+-				   loff_t off, size_t count)
+-{
+-	struct mlxsw_qsfp *mlxsw_qsfp = dev_get_platdata(container_of(kobj,
+-							 struct device, kobj));
+-	u8 *module_ind = attr->private;
+-	size_t size;
+-
+-	size = mlxsw_qsfp->eeprom[*module_ind].size;
+-
+-	if (off > size)
+-		return -ESPIPE;
+-	else if (off == size)
+-		return 0;
+-	else if ((off + count) > size)
+-		count = size - off;
+-
+-	return mlxsw_qsfp_get_module_eeprom(mlxsw_qsfp, *module_ind, buf, off,
+-					    count);
+-}
+-
+-static ssize_t
+-mlxsw_qsfp_status_show(struct device *dev, struct device_attribute *attr,
+-		       char *buf)
+-{
+-	struct mlxsw_qsfp *mlxsw_qsfp = dev_get_platdata(dev);
+-	char mcia_pl[MLXSW_REG_MCIA_LEN];
+-	int status;
+-	u32 i;
+-	int err;
+-
+-	for (i = 0; i < mlxsw_qsfp->module_count; i++) {
+-		if ((mlxsw_qsfp->dev_attrs + i) == attr)
+-			break;
+-	}
+-	if (i == mlxsw_qsfp->module_count)
+-		return -EINVAL;
+-
+-	if (time_before(jiffies, mlxsw_qsfp->modules[i].last_updated +
+-			MLXSW_QSFP_STATUS_VALID_TIME))
+-		return sprintf(buf, "%u\n",
+-			       mlxsw_qsfp->modules[i].cache_status);
+-
+-	mlxsw_reg_mcia_pack(mcia_pl, i, 0, 0, 0, MLXSW_QSFP_MIN_REQ_LEN,
+-			    MLXSW_QSFP_I2C_ADDR);
+-	err = mlxsw_reg_query(mlxsw_qsfp->core, MLXSW_REG(mcia), mcia_pl);
+-	if (err)
+-		return err;
+-
+-	status = mlxsw_reg_mcia_status_get(mcia_pl);
+-	mlxsw_qsfp->modules[i].cache_status = !status;
+-	mlxsw_qsfp->modules[i].last_updated = jiffies;
+-
+-	return sprintf(buf, "%u\n", !status);
+-}
+-
+ static ssize_t
+ mlxsw_qsfp_cpld_show(struct device *dev, struct device_attribute *attr,
+ 		     char *buf)
+@@ -239,13 +86,6 @@ static int mlxsw_qsfp_dmi_set_cpld_num(const struct dmi_system_id *dmi)
+ 	return 1;
+ };
+ 
+-static int mlxsw_qsfp_dmi_set_qsfp_num(const struct dmi_system_id *dmi)
+-{
+-	mlxsw_qsfp_num = MLXSW_QSFP_MAX_NUM;
+-
+-	return 1;
+-};
+-
+ static const struct dmi_system_id mlxsw_qsfp_dmi_table[] = {
+ 	{
+ 		.callback = mlxsw_qsfp_dmi_set_cpld_num,
+@@ -261,55 +101,18 @@ static const struct dmi_system_id mlxsw_qsfp_dmi_table[] = {
+ 			DMI_MATCH(DMI_PRODUCT_NAME, "MSN27"),
+ 		},
+ 	},
+-	{
+-		.callback = mlxsw_qsfp_dmi_set_qsfp_num,
+-		.matches = {
+-			DMI_MATCH(DMI_BOARD_VENDOR, "Mellanox Technologies"),
+-			DMI_MATCH(DMI_PRODUCT_NAME, "MSN37"),
+-		},
+-	},
+-	{
+-		.callback = mlxsw_qsfp_dmi_set_qsfp_num,
+-		.matches = {
+-			DMI_MATCH(DMI_BOARD_VENDOR, "Mellanox Technologies"),
+-			DMI_MATCH(DMI_PRODUCT_NAME, "MSN38"),
+-		},
+-	},
+ 	{ }
+ };
+ MODULE_DEVICE_TABLE(dmi, mlxsw_qsfp_dmi_table);
+ 
+-static int mlxsw_qsfp_set_module_num(struct mlxsw_qsfp *mlxsw_qsfp)
+-{
+-	char pmlp_pl[MLXSW_REG_PMLP_LEN];
+-	u8 width;
+-	int i, err;
+-
+-	for (i = 1; i <= mlxsw_qsfp_num; i++) {
+-		mlxsw_reg_pmlp_pack(pmlp_pl, i);
+-		err = mlxsw_reg_query(mlxsw_qsfp->core, MLXSW_REG(pmlp),
+-				      pmlp_pl);
+-		if (err)
+-			return err;
+-		width = mlxsw_reg_pmlp_width_get(pmlp_pl);
+-		if (!width)
+-			continue;
+-		mlxsw_qsfp->module_count++;
+-	}
+-
+-	return 0;
+-}
+ 
+ int mlxsw_qsfp_init(struct mlxsw_core *mlxsw_core,
+ 		    const struct mlxsw_bus_info *mlxsw_bus_info,
+ 		    struct mlxsw_qsfp **p_qsfp)
+ {
+-	struct device_attribute *dev_attr, *cpld_dev_attr;
+-	char mgpir_pl[MLXSW_REG_MGPIR_LEN];
++	struct device_attribute *cpld_dev_attr;
+ 	struct mlxsw_qsfp *mlxsw_qsfp;
+-	struct bin_attribute *eeprom;
+-	int i, count;
+-	int err;
++	int i, err;
+ 
+ 	if (!strcmp(mlxsw_bus_info->device_kind, "i2c"))
+ 		return 0;
+@@ -324,41 +127,6 @@ int mlxsw_qsfp_init(struct mlxsw_core *mlxsw_core,
+ 	mlxsw_qsfp->core = mlxsw_core;
+ 	mlxsw_qsfp->bus_info = mlxsw_bus_info;
+ 	mlxsw_bus_info->dev->platform_data = mlxsw_qsfp;
+-
+-	mlxsw_reg_mgpir_pack(mgpir_pl);
+-	err = mlxsw_reg_query(mlxsw_qsfp->core, MLXSW_REG(mgpir), mgpir_pl);
+-	if (err) {
+-		err = mlxsw_qsfp_set_module_num(mlxsw_qsfp);
+-		if (err)
+-			return err;
+-	} else {
+-		mlxsw_reg_mgpir_unpack(mgpir_pl, NULL, NULL, NULL,
+-			       &mlxsw_qsfp->module_count);
+-		if (!mlxsw_qsfp->module_count)
+-			return 0;
+-	}
+-
+-	count = mlxsw_qsfp->module_count + 1;
+-	mlxsw_qsfp->eeprom = devm_kzalloc(mlxsw_bus_info->dev,
+-					  mlxsw_qsfp->module_count *
+-					  sizeof(*mlxsw_qsfp->eeprom),
+-					  GFP_KERNEL);
+-	if (!mlxsw_qsfp->eeprom)
+-		return -ENOMEM;
+-
+-	mlxsw_qsfp->eeprom_attr_list = devm_kzalloc(mlxsw_bus_info->dev,
+-						    count *
+-						    sizeof(mlxsw_qsfp->eeprom),
+-						    GFP_KERNEL);
+-	if (!mlxsw_qsfp->eeprom_attr_list)
+-		return -ENOMEM;
+-
+-	mlxsw_qsfp->dev_attrs = devm_kzalloc(mlxsw_bus_info->dev, count *
+-					     sizeof(*mlxsw_qsfp->dev_attrs),
+-					     GFP_KERNEL);
+-	if (!mlxsw_qsfp->dev_attrs)
+-		return -ENOMEM;
+-
+ 	mlxsw_qsfp->cpld_dev_attrs = devm_kzalloc(mlxsw_bus_info->dev,
+ 					mlxsw_qsfp_cpld_num *
+ 					sizeof(*mlxsw_qsfp->cpld_dev_attrs),
+@@ -366,37 +134,6 @@ int mlxsw_qsfp_init(struct mlxsw_core *mlxsw_core,
+ 	if (!mlxsw_qsfp->cpld_dev_attrs)
+ 		return -ENOMEM;
+ 
+-	eeprom = mlxsw_qsfp->eeprom;
+-	dev_attr = mlxsw_qsfp->dev_attrs;
+-	for (i = 0; i < mlxsw_qsfp->module_count; i++, eeprom++, dev_attr++) {
+-		dev_attr->show = mlxsw_qsfp_status_show;
+-		dev_attr->attr.mode = 0444;
+-		dev_attr->attr.name = devm_kasprintf(mlxsw_bus_info->dev,
+-						     GFP_KERNEL,
+-						     "qsfp%d_status", i + 1);
+-		mlxsw_qsfp->attrs[i] = &dev_attr->attr;
+-		sysfs_attr_init(&dev_attr->attr);
+-		err = sysfs_create_file(&mlxsw_bus_info->dev->kobj,
+-					mlxsw_qsfp->attrs[i]);
+-		if (err)
+-			goto err_create_file;
+-
+-		sysfs_bin_attr_init(eeprom);
+-		eeprom->attr.name = devm_kasprintf(mlxsw_bus_info->dev,
+-						   GFP_KERNEL, "qsfp%d",
+-						   i + 1);
+-		eeprom->attr.mode = 0444;
+-		eeprom->read = mlxsw_qsfp_bin_read;
+-		eeprom->size = MLXSW_QSFP_PAGE_NUM * MLXSW_QSFP_PAGE_SIZE;
+-		mlxsw_qsfp->module_ind[i] = i;
+-		eeprom->private = &mlxsw_qsfp->module_ind[i];
+-		mlxsw_qsfp->eeprom_attr_list[i] = eeprom;
+-		err = sysfs_create_bin_file(&mlxsw_bus_info->dev->kobj,
+-					    eeprom);
+-		if (err)
+-			goto err_create_bin_file;
+-	}
+-
+ 	cpld_dev_attr = mlxsw_qsfp->cpld_dev_attrs;
+ 	for (i = 0; i < mlxsw_qsfp_cpld_num; i++, cpld_dev_attr++) {
+ 		cpld_dev_attr->show = mlxsw_qsfp_cpld_show;
+@@ -417,19 +154,9 @@ int mlxsw_qsfp_init(struct mlxsw_core *mlxsw_core,
+ 	return 0;
+ 
+ err_create_cpld_file:
+-	sysfs_remove_file(&mlxsw_bus_info->dev->kobj,
+-			  mlxsw_qsfp->cpld_attrs[i--]);
+-	i = mlxsw_qsfp->module_count;
+-err_create_bin_file:
+-	sysfs_remove_file(&mlxsw_bus_info->dev->kobj,
+-			  mlxsw_qsfp->attrs[i--]);
+-err_create_file:
+-	while (--i > 0) {
+-		sysfs_remove_bin_file(&mlxsw_bus_info->dev->kobj,
+-				      mlxsw_qsfp->eeprom_attr_list[i]);
++	while (--i > 0)
+ 		sysfs_remove_file(&mlxsw_bus_info->dev->kobj,
+-				  mlxsw_qsfp->attrs[i]);
+-	}
++				  mlxsw_qsfp->cpld_attrs[i]);
+ 
+ 	return err;
+ }
+@@ -438,15 +165,11 @@ void mlxsw_qsfp_fini(struct mlxsw_qsfp *mlxsw_qsfp)
+ {
+ 	int i;
+ 
+-	if (!strcmp(mlxsw_qsfp->bus_info->device_kind, "i2c"))
+-		return;
+-
+-	for (i = mlxsw_qsfp->module_count - 1; i >= 0; i--) {
+-		sysfs_remove_bin_file(&mlxsw_qsfp->bus_info->dev->kobj,
+-				      mlxsw_qsfp->eeprom_attr_list[i]);
++	for (i = 0; i < mlxsw_qsfp_cpld_num; i++)
+ 		sysfs_remove_file(&mlxsw_qsfp->bus_info->dev->kobj,
+-				  mlxsw_qsfp->attrs[i]);
+-	}
++				  mlxsw_qsfp->cpld_attrs[i]);
++	devm_kfree(mlxsw_qsfp->bus_info->dev, mlxsw_qsfp->cpld_dev_attrs);
++	devm_kfree(mlxsw_qsfp->bus_info->dev, mlxsw_qsfp);
+ }
+ 
+ MODULE_LICENSE("Dual BSD/GPL");
+-- 
+2.11.0
+

--- a/patch/0066-platform-mellanox-mlxreg-hotplug-Add-environmental-d.patch
+++ b/patch/0066-platform-mellanox-mlxreg-hotplug-Add-environmental-d.patch
@@ -1,0 +1,76 @@
+From 70806251c220166064c7b9fdb1543f814dbbb3ed Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Thu, 9 Apr 2020 12:06:20 +0300
+Subject: [backport] platform/mellanox: mlxreg-hotplug: Add environmental data
+ to uevent
+
+Send "udev" event with environmental data in order to allow handling
+"ENV{}" variables in "udev" rules.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/platform/mellanox/mlxreg-hotplug.c | 28 ++++++++++++++++++++++++++--
+ 1 file changed, 26 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlxreg-hotplug.c b/drivers/platform/mellanox/mlxreg-hotplug.c
+index 832fcf282d45..3e99ad9fe553 100644
+--- a/drivers/platform/mellanox/mlxreg-hotplug.c
++++ b/drivers/platform/mellanox/mlxreg-hotplug.c
+@@ -32,6 +32,7 @@
+  */
+ 
+ #include <linux/bitops.h>
++#include <linux/ctype.h>
+ #include <linux/device.h>
+ #include <linux/hwmon.h>
+ #include <linux/hwmon-sysfs.h>
+@@ -97,13 +98,36 @@ struct mlxreg_hotplug_priv_data {
+ 	u8 not_asserted;
+ };
+ 
++/* Environment variables array for udev. */
++static char *mlxreg_hotplug_udev_envp[] = { NULL, NULL };
++
++static int
++mlxreg_hotplug_udev_event_send(struct kobject *kobj,
++			       struct mlxreg_core_data *data, bool action)
++{
++	char event_str[MLXREG_CORE_LABEL_MAX_SIZE + 2];
++	char label[MLXREG_CORE_LABEL_MAX_SIZE] = { 0 };
++	int i;
++
++	mlxreg_hotplug_udev_envp[0] = event_str;
++	for (i = 0; data->label[i]; i++)
++		label[i] = toupper(data->label[i]);
++
++	if (action)
++		snprintf(event_str, MLXREG_CORE_LABEL_MAX_SIZE, "%s=1", label);
++	else
++		snprintf(event_str, MLXREG_CORE_LABEL_MAX_SIZE, "%s=0", label);
++
++	return kobject_uevent_env(kobj, KOBJ_CHANGE, mlxreg_hotplug_udev_envp);
++}
++
+ static int mlxreg_hotplug_device_create(struct mlxreg_hotplug_priv_data *priv,
+ 					struct mlxreg_core_data *data)
+ {
+ 	struct mlxreg_core_hotplug_platform_data *pdata;
+ 
+ 	/* Notify user by sending hwmon uevent. */
+-	kobject_uevent(&priv->hwmon->kobj, KOBJ_CHANGE);
++	mlxreg_hotplug_udev_event_send(&priv->hwmon->kobj, data, true);
+ 
+ 	/*
+ 	 * Return if adapter number is negative. It could be in case hotplug
+@@ -141,7 +165,7 @@ mlxreg_hotplug_device_destroy(struct mlxreg_hotplug_priv_data *priv,
+ 			      struct mlxreg_core_data *data)
+ {
+ 	/* Notify user by sending hwmon uevent. */
+-	kobject_uevent(&priv->hwmon->kobj, KOBJ_CHANGE);
++	mlxreg_hotplug_udev_event_send(&priv->hwmon->kobj, data, false);
+ 
+ 	if (data->hpdev.client) {
+ 		i2c_unregister_device(data->hpdev.client);
+-- 
+2.11.0
+

--- a/patch/series
+++ b/patch/series
@@ -100,6 +100,8 @@ linux-4.13-thermal-intel_pch_thermal-Fix-enable-check-on.patch
 0062-platform-mellanox-mlxreg-hotplug-Use-capability-r.patch
 0063-platform-mellanox-mlxreg-io-Add-support-for-compl.patch
 0064-Add-config-for-sensor-xdpe122-and-modify-mlx_wdt-.patch
+0065-mlxsw-qsfp_sysfs-Remove-obsolete-code-for-QSFP-EEPRO.patch
+0066-platform-mellanox-mlxreg-hotplug-Add-environmental-d.patch
 linux-4.16-firmware-dmi-handle-missing-DMI-data-gracefully.patch
 mellanox-backport-introduce-psample-a-new-genetlink-channel.patch
 mellanox-backport-introduce-tc-sample-action.patch

--- a/patch/series
+++ b/patch/series
@@ -93,6 +93,8 @@ linux-4.13-thermal-intel_pch_thermal-Fix-enable-check-on.patch
 0055-platform-x86-mlx-platform-Add-support-for-next-gener.patch
 0056-mlxsw-core-Add-support-for-new-hardware-device-types.patch
 0057-mlxsw-minimal-Fix-validation-for-FW-minor-version.patch
+0058-mlxsw-core-thermal-Set-default-thermal-trips-at-init.patch
+0059-mlxsw-core-Add-the-hottest-thermal-zone-detection.patch
 linux-4.16-firmware-dmi-handle-missing-DMI-data-gracefully.patch
 mellanox-backport-introduce-psample-a-new-genetlink-channel.patch
 mellanox-backport-introduce-tc-sample-action.patch

--- a/patch/series
+++ b/patch/series
@@ -95,6 +95,11 @@ linux-4.13-thermal-intel_pch_thermal-Fix-enable-check-on.patch
 0057-mlxsw-minimal-Fix-validation-for-FW-minor-version.patch
 0058-mlxsw-core-thermal-Set-default-thermal-trips-at-init.patch
 0059-mlxsw-core-Add-the-hottest-thermal-zone-detection.patch
+0060-hwmon-pmbus-core-Add-support-for-vid-mode-detecti.patch
+0061-i2c-busses-i2c-mlxcpld-Increase-transaction-pooli.patch
+0062-platform-mellanox-mlxreg-hotplug-Use-capability-r.patch
+0063-platform-mellanox-mlxreg-io-Add-support-for-compl.patch
+0064-Add-config-for-sensor-xdpe122-and-modify-mlx_wdt-.patch
 linux-4.16-firmware-dmi-handle-missing-DMI-data-gracefully.patch
 mellanox-backport-introduce-psample-a-new-genetlink-channel.patch
 mellanox-backport-introduce-tc-sample-action.patch


### PR DESCRIPTION
**What I did:**

Added four patches along with hw-mgmt V.7.0000.3034:
0058-mlxsw-qsfp_sysfs-Remove-obsolete-code-for-QSFP-EEPRO.patch
0059-platform-mellanox-mlxreg-hotplug-Add-environmental-d.patch