### PR TITLE
[Mellanox] Add new patches come along with hw-mgmt V.7.0000.3034

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 KERNEL_ABI_MINOR_VERSION = 2
-KVERSION_SHORT ?= 4.9.0-9-$(KERNEL_ABI_MINOR_VERSION)
+KVERSION_SHORT ?= 4.9.0-11-$(KERNEL_ABI_MINOR_VERSION)
 KVERSION ?= $(KVERSION_SHORT)-amd64
-KERNEL_VERSION ?= 4.9.168
-KERNEL_SUBVERSION ?= 1+deb9u5
+KERNEL_VERSION ?= 4.9.189
+KERNEL_SUBVERSION ?= 3+deb9u2
 kernel_procure_method ?= build
 
 LINUX_HEADER_COMMON = linux-headers-$(KVERSION_SHORT)-common_$(KERNEL_VERSION)-$(KERNEL_SUBVERSION)_all.deb
@@ -47,9 +47,9 @@ ORIG_FILE = linux_$(KERNEL_VERSION).orig.tar.xz
 DEBIAN_FILE = linux_$(KERNEL_VERSION)-$(KERNEL_SUBVERSION).debian.tar.xz
 BUILD_DIR=linux-$(KERNEL_VERSION)
 
-DSC_FILE_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-source/linux_4.9.168-1+deb9u5.dsc?sv=2015-04-05&sr=b&sig=ZcTpvRltWLWwnJn3vQ%2BgTP1dVF6QSinOCJ1FSuyiogU%3D&se=2033-04-28T06%3A14%3A30Z&sp=r"
-DEBIAN_FILE_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-source/linux_4.9.168-1+deb9u5.debian.tar.xz?sv=2015-04-05&sr=b&sig=koCXHDvmY39smVGcI3cPJrBDZMmdpKiLkyJPfMdNPwU%3D&se=2033-04-28T06%3A14%3A51Z&sp=r"
-ORIG_FILE_URL = "https://sonicstorage.blob.core.windows.net/packages/kernel-source/linux_4.9.168.orig.tar.xz?sv=2015-04-05&sr=b&sig=ArvSGD3N46WGh%2BTYF8J1JgdT9x0BrFu4JhSuyyr3nNw%3D&se=2033-04-09T01%3A00%3A47Z&sp=r"
+DSC_FILE_URL = "http://security.debian.org/debian-security/pool/updates/main/l/linux/linux_4.9.189-3+deb9u2.dsc"
+DEBIAN_FILE_URL = "http://security.debian.org/debian-security/pool/updates/main/l/linux/linux_4.9.189-3+deb9u2.debian.tar.xz"
+ORIG_FILE_URL = "http://security.debian.org/debian-security/pool/updates/main/l/linux/linux_4.9.189.orig.tar.xz"
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Obtaining the Debian kernel source

--- a/patch/0001-net-ipv6-Allow-shorthand-delete-of-all-nexthops-in-m.patch
+++ b/patch/0001-net-ipv6-Allow-shorthand-delete-of-all-nexthops-in-m.patch
@@ -1,0 +1,140 @@
+From 055d25a3f712c2fcb16a171786e487739953d471 Mon Sep 17 00:00:00 2001
+From: Preetham Singh <preetham.singh@broadcom.com>
+Date: Wed, 18 Sep 2019 02:54:13 -0700
+Subject: [PATCH] net: ipv6: Allow shorthand delete of all
+ nexthops in  multipath route
+
+This was already supported by IPv4 but missing for IPv6. This commit
+brings shorthand delete of IPv6 multipath routes in kernel.
+
+Successive delete of multi-path routes(32 paths) was not clearing all routes in kernel though frr was sending RTM_DELROUTE when last nexthop was getting deleted. Reason being For IPv6 delete route in kernel, expects all nhops to be sent. On counter part, IPv4 route delete in kernel does NOT expect all nhops to be sent. FRR currently doesnt send any nhops when operation is RTM_DELROUTE for both IPv4 & IPv6.
+
+back porting below changes from newer version of kernel
+https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/net/ipv6/route.c?h=v4.14.144&id=0ae8133586ad1c9be894411aaf8b17bb58c8efe5
+
+After importing above patch, there were no stale IPv6 routes in kernel.
+
+Signed-off-by: Preetham Singh <preetham.singh@broadcom.com>
+---
+ include/net/ip6_fib.h |  4 ++-
+ net/ipv6/route.c      | 67 +++++++++++++++++++++++++++++++++++++++++--
+ 2 files changed, 68 insertions(+), 3 deletions(-)
+
+diff --git a/include/net/ip6_fib.h b/include/net/ip6_fib.h
+index a6bcb18..82ef4ba 100644
+--- a/include/net/ip6_fib.h
++++ b/include/net/ip6_fib.h
+@@ -37,7 +37,9 @@ struct fib6_config {
+ 	int		fc_ifindex;
+ 	u32		fc_flags;
+ 	u32		fc_protocol;
+-	u32		fc_type;	/* only 8 bits are used */
++	u16     fc_type;        /* only 8 bits are used */
++	u16     fc_delete_all_nh : 1,
++			__unused : 15;
+ 
+ 	struct in6_addr	fc_dst;
+ 	struct in6_addr	fc_src;
+diff --git a/net/ipv6/route.c b/net/ipv6/route.c
+index 7dcd34f..9743662 100644
+--- a/net/ipv6/route.c
++++ b/net/ipv6/route.c
+@@ -98,6 +98,12 @@ static void		rt6_do_redirect(struct dst_entry *dst, struct sock *sk,
+ 					struct sk_buff *skb);
+ static void		rt6_dst_from_metrics_check(struct rt6_info *rt);
+ static int rt6_score_route(struct rt6_info *rt, int oif, int strict);
++static size_t rt6_nlmsg_size(struct rt6_info *rt);
++static int rt6_fill_node(struct net *net,
++			 struct sk_buff *skb, struct rt6_info *rt,
++			 struct in6_addr *dst, struct in6_addr *src,
++			 int iif, int type, u32 portid, u32 seq,
++			 int prefix, int nowait, unsigned int flags);
+ 
+ #ifdef CONFIG_IPV6_ROUTE_INFO
+ static struct rt6_info *rt6_add_route_info(struct net *net,
+@@ -2183,6 +2189,57 @@ int ip6_del_rt(struct rt6_info *rt)
+ 	return __ip6_del_rt(rt, &info);
+ }
+ 
++static int __ip6_del_rt_siblings(struct rt6_info *rt, struct fib6_config *cfg)
++{
++	struct nl_info *info = &cfg->fc_nlinfo;
++	struct net *net = info->nl_net;
++	struct sk_buff *skb = NULL;
++	struct fib6_table *table;
++	int err = -ENOENT;
++
++	if (rt == net->ipv6.ip6_null_entry)
++		goto out_put;
++	table = rt->rt6i_table;
++	write_lock_bh(&table->tb6_lock);
++
++	if (rt->rt6i_nsiblings && cfg->fc_delete_all_nh) {
++		struct rt6_info *sibling, *next_sibling;
++
++		/* prefer to send a single notification with all hops */
++		skb = nlmsg_new(rt6_nlmsg_size(rt), gfp_any());
++		if (skb) {
++			u32 seq = info->nlh ? info->nlh->nlmsg_seq : 0;
++
++			if (rt6_fill_node(net, skb, rt,
++					  NULL, NULL, 0, RTM_DELROUTE,
++					  info->portid, seq, 0, 0, 0) < 0) {
++				kfree_skb(skb);
++				skb = NULL;
++			}
++		}
++
++		list_for_each_entry_safe(sibling, next_sibling,
++					 &rt->rt6i_siblings,
++					 rt6i_siblings) {
++			err = fib6_del(sibling, info);
++			if (err)
++				goto out_unlock;
++		}
++	}
++
++	err = fib6_del(rt, info);
++out_unlock:
++	write_unlock_bh(&table->tb6_lock);
++out_put:
++	ip6_rt_put(rt);
++
++	if (skb) {
++		rtnl_notify(skb, net, info->portid, RTNLGRP_IPV6_ROUTE,
++			    info->nlh, gfp_any());
++	}
++	return err;
++}
++
+ static int ip6_route_del(struct fib6_config *cfg)
+ {
+ 	struct fib6_table *table;
+@@ -2219,7 +2276,11 @@ static int ip6_route_del(struct fib6_config *cfg)
+ 			dst_hold(&rt->dst);
+ 			read_unlock_bh(&table->tb6_lock);
+ 
+-			return __ip6_del_rt(rt, &cfg->fc_nlinfo);
++            /* if gateway was specified only delete the one hop */
++            if (cfg->fc_flags & RTF_GATEWAY)
++			    return __ip6_del_rt(rt, &cfg->fc_nlinfo);
++
++		    return __ip6_del_rt_siblings(rt, cfg);
+ 		}
+ 	}
+ 	read_unlock_bh(&table->tb6_lock);
+@@ -3167,8 +3228,10 @@ static int inet6_rtm_delroute(struct sk_buff *skb, struct nlmsghdr *nlh)
+ 
+ 	if (cfg.fc_mp)
+ 		return ip6_route_multipath_del(&cfg);
+-	else
++	else {
++		cfg.fc_delete_all_nh = 1;
+ 		return ip6_route_del(&cfg);
++	}
+ }
+ 
+ static int inet6_rtm_newroute(struct sk_buff *skb, struct nlmsghdr *nlh)
+-- 
+2.18.0
+

--- a/patch/0048-mlxsw-core-Skip-thermal-zone-operations-initializati.patch
+++ b/patch/0048-mlxsw-core-Skip-thermal-zone-operations-initializati.patch
@@ -1,0 +1,101 @@
+From 2a2cd8876916ffaf530053a5e1f05940258eab86 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Tue, 5 Nov 2019 15:25:22 +0200
+Subject: [PATCH v1] mlxsw: core: Skip thermal zone operations initialization
+
+Skip thermal zones setting for modules to reduce probing time.
+It is to be read anyway during thermal zone operations.
+Skip thermal zone setting and reading during initialization.
+
+Decrease i2c controller polling time from 2000usec to 200usec
+for the performance improvement.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/i2c/busses/i2c-mlxcpld.c                   |  2 +-
+ drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 21 +++++++++++++++++++++
+ 2 files changed, 22 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/i2c/busses/i2c-mlxcpld.c b/drivers/i2c/busses/i2c-mlxcpld.c
+index 2fd717d8dd30..41b57027e348 100644
+--- a/drivers/i2c/busses/i2c-mlxcpld.c
++++ b/drivers/i2c/busses/i2c-mlxcpld.c
+@@ -51,7 +51,7 @@
+ #define MLXCPLD_I2C_MAX_ADDR_LEN	4
+ #define MLXCPLD_I2C_RETR_NUM		2
+ #define MLXCPLD_I2C_XFER_TO		500000 /* usec */
+-#define MLXCPLD_I2C_POLL_TIME		2000   /* usec */
++#define MLXCPLD_I2C_POLL_TIME		200   /* usec */
+ 
+ /* LPC I2C registers */
+ #define MLXCPLD_LPCI2C_CPBLTY_REG	0x0
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+index dfaad30ae960..08458e30e171 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+@@ -116,6 +116,7 @@ struct mlxsw_thermal {
+ 	u8 tz_gearbox_num;
+ 	unsigned int tz_highest_score;
+ 	struct thermal_zone_device *tz_highest_dev;
++	bool initializing; /* Driver is in initialization stage */
+ };
+ 
+ static inline u8 mlxsw_state_to_duty(int state)
+@@ -287,6 +288,12 @@ static int mlxsw_thermal_get_temp(struct thermal_zone_device *tzdev,
+ 	int temp;
+ 	int err;
+ 
++	/* Do not read temperature in initialization stage. */
++	if (thermal->initializing) {
++		*p_temp = 0;
++		return 0;
++	}
++
+ 	mlxsw_reg_mtmp_pack(mtmp_pl, 0, false, false);
+ 
+ 	err = mlxsw_reg_query(thermal->core, MLXSW_REG(mtmp), mtmp_pl);
+@@ -458,6 +465,12 @@ static int mlxsw_thermal_module_temp_get(struct thermal_zone_device *tzdev,
+ 	int temp;
+ 	int err;
+ 
++	/* Do not read temperature in initialization stage. */
++	if (thermal->initializing) {
++		*p_temp = 0;
++		return 0;
++	}
++
+ 	/* Read module temperature. */
+ 	mlxsw_reg_mtmp_pack(mtmp_pl, MLXSW_REG_MTMP_MODULE_INDEX_MIN +
+ 			    tz->module, false, false);
+@@ -565,6 +578,12 @@ static int mlxsw_thermal_gearbox_temp_get(struct thermal_zone_device *tzdev,
+ 	int temp;
+ 	int err;
+ 
++	/* Do not read temperature in initialization stage. */
++	if (thermal->initializing) {
++		*p_temp = 0;
++		return 0;
++	}
++
+ 	index = MLXSW_REG_MTMP_GBOX_INDEX_MIN + tz->module;
+ 	mlxsw_reg_mtmp_pack(mtmp_pl, index, false, false);
+ 
+@@ -919,6 +938,7 @@ int mlxsw_thermal_init(struct mlxsw_core *core,
+ 	thermal->core = core;
+ 	thermal->bus_info = bus_info;
+ 	memcpy(thermal->trips, default_thermal_trips, sizeof(thermal->trips));
++	thermal->initializing = true;
+ 
+ 	err = mlxsw_reg_query(thermal->core, MLXSW_REG(mfcr), mfcr_pl);
+ 	if (err) {
+@@ -994,6 +1014,7 @@ int mlxsw_thermal_init(struct mlxsw_core *core,
+ 		goto err_unreg_modules_tzdev;
+ 
+ 	thermal->mode = THERMAL_DEVICE_DISABLED;
++	thermal->initializing = false;
+ 	*p_thermal = thermal;
+ 	return 0;
+ 
+-- 
+2.11.0
+

--- a/patch/0049-thermal-Fix-use-after-free-when-unregistering-therma.patch
+++ b/patch/0049-thermal-Fix-use-after-free-when-unregistering-therma.patch
@@ -1,0 +1,138 @@
+From 09246e73df900b96b534d6b7ccd26a681facb4d5 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Tue, 26 Nov 2019 09:09:45 +0200
+Subject: [PATCH backport bugfix from v5.3] thermal: Fix use-after-free when
+ unregistering thermal zone device
+
+Upstream commit 1851799e1d2978f68eea5d9dff322e121dcf59c1
+Author: Ido Schimmel <idosch@mellanox.com>
+Date:   Wed Jul 10 13:14:52 2019 +0300
+
+thermal: Fix use-after-free when unregistering thermal zone device
+
+thermal_zone_device_unregister() cancels the delayed work that polls the
+thermal zone, but it does not wait for it to finish. This is racy with
+respect to the freeing of the thermal zone device, which can result in a
+use-after-free [1].
+
+Fix this by waiting for the delayed work to finish before freeing the
+thermal zone device. Note that thermal_zone_device_set_polling() is
+never invoked from an atomic context, so it is safe to call
+cancel_delayed_work_sync() that can block.
+
+[1]
+[  +0.002221] ==================================================================
+[  +0.000064] BUG: KASAN: use-after-free in __mutex_lock+0x1076/0x11c0
+[  +0.000016] Read of size 8 at addr ffff8881e48e0450 by task kworker/1:0/17
+
+[  +0.000023] CPU: 1 PID: 17 Comm: kworker/1:0 Not tainted 5.2.0-rc6-custom-02495-g8e73ca3be4af #1701
+[  +0.000010] Hardware name: Mellanox Technologies Ltd. MSN2100-CB2FO/SA001017, BIOS 5.6.5 06/07/2016
+[  +0.000016] Workqueue: events_freezable_power_ thermal_zone_device_check
+[  +0.000012] Call Trace:
+[  +0.000021]  dump_stack+0xa9/0x10e
+[  +0.000020]  print_address_description.cold.2+0x9/0x25e
+[  +0.000018]  __kasan_report.cold.3+0x78/0x9d
+[  +0.000016]  kasan_report+0xe/0x20
+[  +0.000016]  __mutex_lock+0x1076/0x11c0
+[  +0.000014]  step_wise_throttle+0x72/0x150
+[  +0.000018]  handle_thermal_trip+0x167/0x760
+[  +0.000019]  thermal_zone_device_update+0x19e/0x5f0
+[  +0.000019]  process_one_work+0x969/0x16f0
+[  +0.000017]  worker_thread+0x91/0xc40
+[  +0.000014]  kthread+0x33d/0x400
+[  +0.000015]  ret_from_fork+0x3a/0x50
+
+[  +0.000020] Allocated by task 1:
+[  +0.000015]  save_stack+0x19/0x80
+[  +0.000015]  __kasan_kmalloc.constprop.4+0xc1/0xd0
+[  +0.000014]  kmem_cache_alloc_trace+0x152/0x320
+[  +0.000015]  thermal_zone_device_register+0x1b4/0x13a0
+[  +0.000015]  mlxsw_thermal_init+0xc92/0x23d0
+[  +0.000014]  __mlxsw_core_bus_device_register+0x659/0x11b0
+[  +0.000013]  mlxsw_core_bus_device_register+0x3d/0x90
+[  +0.000013]  mlxsw_pci_probe+0x355/0x4b0
+[  +0.000014]  local_pci_probe+0xc3/0x150
+[  +0.000013]  pci_device_probe+0x280/0x410
+[  +0.000013]  really_probe+0x26a/0xbb0
+[  +0.000013]  driver_probe_device+0x208/0x2e0
+[  +0.000013]  device_driver_attach+0xfe/0x140
+[  +0.000013]  __driver_attach+0x110/0x310
+[  +0.000013]  bus_for_each_dev+0x14b/0x1d0
+[  +0.000013]  driver_register+0x1c0/0x400
+[  +0.000015]  mlxsw_sp_module_init+0x5d/0xd3
+[  +0.000014]  do_one_initcall+0x239/0x4dd
+[  +0.000013]  kernel_init_freeable+0x42b/0x4e8
+[  +0.000012]  kernel_init+0x11/0x18b
+[  +0.000013]  ret_from_fork+0x3a/0x50
+
+[  +0.000015] Freed by task 581:
+[  +0.000013]  save_stack+0x19/0x80
+[  +0.000014]  __kasan_slab_free+0x125/0x170
+[  +0.000013]  kfree+0xf3/0x310
+[  +0.000013]  thermal_release+0xc7/0xf0
+[  +0.000014]  device_release+0x77/0x200
+[  +0.000014]  kobject_put+0x1a8/0x4c0
+[  +0.000014]  device_unregister+0x38/0xc0
+[  +0.000014]  thermal_zone_device_unregister+0x54e/0x6a0
+[  +0.000014]  mlxsw_thermal_fini+0x184/0x35a
+[  +0.000014]  mlxsw_core_bus_device_unregister+0x10a/0x640
+[  +0.000013]  mlxsw_devlink_core_bus_device_reload+0x92/0x210
+[  +0.000015]  devlink_nl_cmd_reload+0x113/0x1f0
+[  +0.000014]  genl_family_rcv_msg+0x700/0xee0
+[  +0.000013]  genl_rcv_msg+0xca/0x170
+[  +0.000013]  netlink_rcv_skb+0x137/0x3a0
+[  +0.000012]  genl_rcv+0x29/0x40
+[  +0.000013]  netlink_unicast+0x49b/0x660
+[  +0.000013]  netlink_sendmsg+0x755/0xc90
+[  +0.000013]  __sys_sendto+0x3de/0x430
+[  +0.000013]  __x64_sys_sendto+0xe2/0x1b0
+[  +0.000013]  do_syscall_64+0xa4/0x4d0
+[  +0.000013]  entry_SYSCALL_64_after_hwframe+0x49/0xbe
+
+[  +0.000017] The buggy address belongs to the object at ffff8881e48e0008
+   which belongs to the cache kmalloc-2k of size 2048
+[  +0.000012] The buggy address is located 1096 bytes inside of
+   2048-byte region [ffff8881e48e0008, ffff8881e48e0808)
+[  +0.000007] The buggy address belongs to the page:
+[  +0.000012] page:ffffea0007923800 refcount:1 mapcount:0 mapping:ffff88823680d0c0 index:0x0 compound_mapcount: 0
+[  +0.000020] flags: 0x200000000010200(slab|head)
+[  +0.000019] raw: 0200000000010200 ffffea0007682008 ffffea00076ab808 ffff88823680d0c0
+[  +0.000016] raw: 0000000000000000 00000000000d000d 00000001ffffffff 0000000000000000
+[  +0.000007] page dumped because: kasan: bad access detected
+
+[  +0.000012] Memory state around the buggy address:
+[  +0.000012]  ffff8881e48e0300: fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb
+[  +0.000012]  ffff8881e48e0380: fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb
+[  +0.000012] >ffff8881e48e0400: fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb
+[  +0.000008]  ^
+[  +0.000012]  ffff8881e48e0480: fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb
+[  +0.000012]  ffff8881e48e0500: fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb fb
+[  +0.000007] ==================================================================
+
+Fixes: b1569e99c795 ("ACPI: move thermal trip handling to generic thermal layer")
+Reported-by: Jiri Pirko <jiri@mellanox.com>
+Signed-off-by: Ido Schimmel <idosch@mellanox.com>
+Acked-by: Jiri Pirko <jiri@mellanox.com>
+Signed-off-by: Zhang Rui <rui.zhang@intel.com>
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/thermal/thermal_core.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/thermal/thermal_core.c b/drivers/thermal/thermal_core.c
+index 226b0b4aced6..7be7017f0d9e 100644
+--- a/drivers/thermal/thermal_core.c
++++ b/drivers/thermal/thermal_core.c
+@@ -402,7 +402,7 @@ static void thermal_zone_device_set_polling(struct thermal_zone_device *tz,
+ 		mod_delayed_work(system_freezable_wq, &tz->poll_queue,
+ 				 msecs_to_jiffies(delay));
+ 	else
+-		cancel_delayed_work(&tz->poll_queue);
++		cancel_delayed_work_sync(&tz->poll_queue);
+ }
+ 
+ static void monitor_thermal_zone(struct thermal_zone_device *tz)
+-- 
+2.11.0
+

--- a/patch/0050-mlxsw-core-Drop-creation-of-thermal-to-hwmon-sysfs-i.patch
+++ b/patch/0050-mlxsw-core-Drop-creation-of-thermal-to-hwmon-sysfs-i.patch
@@ -1,0 +1,73 @@
+From 539b36ac336510610b22b134284af5ecb2dc5009 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Thu, 28 Nov 2019 08:34:22 +0200
+Subject: [PATCH mlxsw: thermal] mlxsw: core: Drop creation of thermal to hwmon
+ sysfs interface
+
+Drop creation of "hwmon" interfaces from "thermal". These interfaces
+are redundant, since they are created by "core_hwmon" component.
+Creation of those interface from "thermal" just causes each temperature
+input entry to by created twice in "hwmon"
+Add thermal zone platform parameters definition with the field
+"no_hwmon" set to true. Use it in thermal_zone_device_register().
+It will indicate that the "thermal" to "hwmon" sysfs interface is not
+required.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 18 +++++++++++-------
+ 1 file changed, 11 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+index c4a426d01c5e..f234416305fd 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+@@ -411,6 +411,10 @@ static int mlxsw_thermal_trend_get(struct thermal_zone_device *tzdev,
+ 	return 0;
+ }
+ 
++struct thermal_zone_params mlxsw_thermal_params = {
++	.no_hwmon = true,
++};
++
+ static struct thermal_zone_device_ops mlxsw_thermal_ops = {
+ 	.bind = mlxsw_thermal_bind,
+ 	.unbind = mlxsw_thermal_unbind,
+@@ -774,11 +778,11 @@ mlxsw_thermal_module_tz_init(struct mlxsw_thermal_module *module_tz)
+ 	snprintf(tz_name, sizeof(tz_name), "mlxsw-module%d",
+ 		 module_tz->module + 1);
+ 	module_tz->tzdev = thermal_zone_device_register(tz_name,
+-							MLXSW_THERMAL_NUM_TRIPS,
+-							MLXSW_THERMAL_TRIP_MASK,
+-							module_tz,
+-							&mlxsw_thermal_module_ops,
+-							NULL, 0, 0);
++						MLXSW_THERMAL_NUM_TRIPS,
++						MLXSW_THERMAL_TRIP_MASK,
++						module_tz,
++						&mlxsw_thermal_module_ops,
++						&mlxsw_thermal_params, 0, 0);
+ 	if (IS_ERR(module_tz->tzdev)) {
+ 		err = PTR_ERR(module_tz->tzdev);
+ 		return err;
+@@ -898,7 +902,7 @@ mlxsw_thermal_gearbox_tz_init(struct mlxsw_thermal_module *gearbox_tz)
+ 						MLXSW_THERMAL_TRIP_MASK,
+ 						gearbox_tz,
+ 						&mlxsw_thermal_gearbox_ops,
+-						NULL, 0, 0);
++						&mlxsw_thermal_params, 0, 0);
+ 	if (IS_ERR(gearbox_tz->tzdev))
+ 		return PTR_ERR(gearbox_tz->tzdev);
+ 
+@@ -1052,7 +1056,7 @@ int mlxsw_thermal_init(struct mlxsw_core *core,
+ 						      MLXSW_THERMAL_TRIP_MASK,
+ 						      thermal,
+ 						      &mlxsw_thermal_ops,
+-						      NULL, 0,
++						      &mlxsw_thermal_params, 0,
+ 						      thermal->polling_delay);
+ 	if (IS_ERR(thermal->tzdev)) {
+ 		err = PTR_ERR(thermal->tzdev);
+-- 
+2.11.0
+

--- a/patch/0051-mlxsw-core-Skip-thermal-zones-threshold-setting-duri.patch
+++ b/patch/0051-mlxsw-core-Skip-thermal-zones-threshold-setting-duri.patch
@@ -1,0 +1,34 @@
+From 031b57148672ff229d42fe4401e552c05e14f87a Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Sun, 1 Dec 2019 17:29:02 +0200
+Subject: [PATCH mlxsw: thermal] mlxsw: core: Skip thermal zones threshold
+ setting during initialization
+
+Skip modules' thermal zones threshold setting during initialization in
+order to reduce driver's probing time.
+This setting will be performed at the first operation with the thermal
+zones.
+
+Signed-off-by: Vadim Pasternak vadimp@mellanox.com
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+index 7fbb7a24eb63..f234416305fd 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+@@ -813,8 +813,8 @@ mlxsw_thermal_module_init(struct device *dev, struct mlxsw_core *core,
+ 	       sizeof(thermal->trips));
+ 	/* Initialize all trip point. */
+ 	mlxsw_thermal_module_trips_reset(module_tz);
+-	/* Update trip point according to the module data. */
+-	return mlxsw_thermal_module_trips_update(dev, core, module_tz);
++
++	return 0;
+ }
+ 
+ static void mlxsw_thermal_module_fini(struct mlxsw_thermal_module *module_tz)
+-- 
+2.20.1
+

--- a/patch/0052-platform-x86-mlx-platform-Add-more-detention-for-sys.patch
+++ b/patch/0052-platform-x86-mlx-platform-Add-more-detention-for-sys.patch
@@ -1,0 +1,35 @@
+From 5df12806208285231c63a8757208648483aaf395 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Tue, 3 Dec 2019 16:02:08 +0200
+Subject: [PATCH platform] platform/x86: mlx-platform: Add more detention for
+ system attributes
+
+Add new attribute for "next-generation" type systems:
+"reset_sw_pwr_off" for indication of reset caused by
+software power off command.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/platform/x86/mlx-platform.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index c3e75b26fe0b..765baf99de60 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -1335,6 +1335,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mask = GENMASK(7, 0) & ~BIT(1),
+ 		.mode = 0444,
+ 	},
++	{
++		.label = "reset_sw_pwr_off",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(2),
++		.mode = 0444,
++	},
+ 	{
+ 		.label = "reset_comex_thermal",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
+-- 
+2.20.1
+

--- a/patch/0053-firmware-dmi-Add-access-to-the-SKU-ID-string-backpor.patch
+++ b/patch/0053-firmware-dmi-Add-access-to-the-SKU-ID-string-backpor.patch
@@ -1,0 +1,88 @@
+From acc9225e1db4bfc710c83c25f34b2b226060c350 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Thu, 23 Jan 2020 14:58:38 +0200
+Subject: [PATCH backport] firmware: dmi: Add access to the SKU ID string
+ backport
+
+Backport of two below upstream commits.
+
+commit b23908d3c48a37c46c6a26df2cdeab1610b360ba
+Author: Simon Glass <sjg@chromium.org>
+Date:   Sun Jun 17 14:09:42 2018 +0200
+
+    firmware: dmi: Add access to the SKU ID string
+
+    This is used in some systems from user space for determining the
+identity
+    of the device.
+
+    Expose this as a file so that that user-space tools don't need to
+read
+    from /sys/firmware/dmi/tables/DMI
+
+    Signed-off-by: Simon Glass <sjg@chromium.org>
+    Signed-off-by: Jean Delvare <jdelvare@suse.de>
+
+commit b23908d3c48a37c46c6a26df2cdeab1610b360ba
+Author: Simon Glass <sjg@chromium.org>
+Date:   Sun Jun 17 14:09:42 2018 +0200
+
+firmware: dmi: Add access to the SKU ID string
+
+    This is used in some systems from user space for determining the
+identity
+    of the device.
+
+    Expose this as a file so that that user-space tools don't need to
+read
+    from /sys/firmware/dmi/tables/DMI
+
+    Signed-off-by: Simon Glass <sjg@chromium.org>
+    Signed-off-by: Jean Delvare <jdelvare@suse.de>
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/firmware/dmi-id.c       | 1 +
+ drivers/firmware/dmi_scan.c     | 1 +
+ include/linux/mod_devicetable.h | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/drivers/firmware/dmi-id.c b/drivers/firmware/dmi-id.c
+index dc269cb288c2..5c864ebe1127 100644
+--- a/drivers/firmware/dmi-id.c
++++ b/drivers/firmware/dmi-id.c
+@@ -47,6 +47,7 @@ DEFINE_DMI_ATTR_WITH_SHOW(product_name,		0444, DMI_PRODUCT_NAME);
+ DEFINE_DMI_ATTR_WITH_SHOW(product_version,	0444, DMI_PRODUCT_VERSION);
+ DEFINE_DMI_ATTR_WITH_SHOW(product_serial,	0400, DMI_PRODUCT_SERIAL);
+ DEFINE_DMI_ATTR_WITH_SHOW(product_uuid,		0400, DMI_PRODUCT_UUID);
++DEFINE_DMI_ATTR_WITH_SHOW(product_sku,		0444, DMI_PRODUCT_SKU);
+ DEFINE_DMI_ATTR_WITH_SHOW(product_family,	0400, DMI_PRODUCT_FAMILY);
+ DEFINE_DMI_ATTR_WITH_SHOW(board_vendor,		0444, DMI_BOARD_VENDOR);
+ DEFINE_DMI_ATTR_WITH_SHOW(board_name,		0444, DMI_BOARD_NAME);
+diff --git a/drivers/firmware/dmi_scan.c b/drivers/firmware/dmi_scan.c
+index 150b923ef86d..d2a85a2e5b08 100644
+--- a/drivers/firmware/dmi_scan.c
++++ b/drivers/firmware/dmi_scan.c
+@@ -426,6 +426,7 @@ static void __init dmi_decode(const struct dmi_header *dm, void *dummy)
+ 		dmi_save_ident(dm, DMI_PRODUCT_VERSION, 6);
+ 		dmi_save_ident(dm, DMI_PRODUCT_SERIAL, 7);
+ 		dmi_save_uuid(dm, DMI_PRODUCT_UUID, 8);
++		dmi_save_ident(dm, DMI_PRODUCT_SKU, 25);
+ 		dmi_save_ident(dm, DMI_PRODUCT_FAMILY, 26);
+ 		break;
+ 	case 2:		/* Base Board Information */
+diff --git a/include/linux/mod_devicetable.h b/include/linux/mod_devicetable.h
+index 616b31a1495d..103c14049a76 100644
+--- a/include/linux/mod_devicetable.h
++++ b/include/linux/mod_devicetable.h
+@@ -456,6 +456,7 @@ enum dmi_field {
+ 	DMI_PRODUCT_VERSION,
+ 	DMI_PRODUCT_SERIAL,
+ 	DMI_PRODUCT_UUID,
++	DMI_PRODUCT_SKU,
+ 	DMI_PRODUCT_FAMILY,
+ 	DMI_BOARD_VENDOR,
+ 	DMI_BOARD_NAME,
+-- 
+2.20.1
+

--- a/patch/0054-platform-x86-mlx-platform-Modify-setting-for-new-sys.patch
+++ b/patch/0054-platform-x86-mlx-platform-Modify-setting-for-new-sys.patch
@@ -1,0 +1,420 @@
+From 7facfc1c55a37b8f28d75d0f2ddf51a0f892730a Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Tue, 17 Dec 2019 15:50:22 +0000
+Subject: [PATCH platform backport 1/2] platform/x86: mlx-platform: Modify
+ setting for new system type
+
+Modify setting for new Mellanox system types of basic class VMOD0009,
+containing Mellanox systems equipped with the switch devices
+Spectrum 1 (32x100GbE Ethernet switch) and Switch-IB/Switch-IB2
+(36x100Gbe InfiniBand switch).
+These are the Top of the Rack system, equipped with Mellanox Comex
+card.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/platform/x86/mlx-platform.c | 194 ++++++++++++++++++++++++++++++------
+ 1 file changed, 165 insertions(+), 29 deletions(-)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index 765baf99de60..1a4fecb770ad 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -90,6 +90,7 @@
+ #define MLXPLAT_CPLD_LPC_IO_RANGE		0x100
+ #define MLXPLAT_CPLD_LPC_I2C_CH1_OFF		0xdb
+ #define MLXPLAT_CPLD_LPC_I2C_CH2_OFF		0xda
++#define MLXPLAT_CPLD_LPC_I2C_CH3_OFF		0xdc
+ 
+ #define MLXPLAT_CPLD_LPC_PIO_OFFSET		0x10000UL
+ #define MLXPLAT_CPLD_LPC_REG1	((MLXPLAT_CPLD_LPC_REG_BASE_ADRR + \
+@@ -98,6 +99,9 @@
+ #define MLXPLAT_CPLD_LPC_REG2	((MLXPLAT_CPLD_LPC_REG_BASE_ADRR + \
+ 				  MLXPLAT_CPLD_LPC_I2C_CH2_OFF) | \
+ 				  MLXPLAT_CPLD_LPC_PIO_OFFSET)
++#define MLXPLAT_CPLD_LPC_REG3	((MLXPLAT_CPLD_LPC_REG_BASE_ADRR + \
++				  MLXPLAT_CPLD_LPC_I2C_CH3_OFF) | \
++				  MLXPLAT_CPLD_LPC_PIO_OFFSET)
+ 
+ /* Masks for aggregation, psu, pwr and fan event in CPLD related registers. */
+ #define MLXPLAT_CPLD_AGGR_ASIC_MASK_DEF	0x04
+@@ -110,7 +114,7 @@
+ #define MLXPLAT_CPLD_AGGR_ASIC_MASK_NG	0x01
+ #define MLXPLAT_CPLD_AGGR_MASK_NG_DEF	0x04
+ #define MLXPLAT_CPLD_AGGR_MASK_COMEX	BIT(0)
+-#define MLXPLAT_CPLD_LOW_AGGR_MASK_LOW	0xe1
++#define MLXPLAT_CPLD_LOW_AGGR_MASK_LOW	0xc1
+ #define MLXPLAT_CPLD_LOW_AGGR_MASK_I2C	BIT(6)
+ #define MLXPLAT_CPLD_PSU_MASK		GENMASK(1, 0)
+ #define MLXPLAT_CPLD_PWR_MASK		GENMASK(1, 0)
+@@ -131,6 +135,7 @@
+ 
+ /* Maximum number of possible physical buses equipped on system */
+ #define MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM	16
++#define MLXPLAT_CPLD_MAX_PHYS_EXT_ADAPTER_NUM	24
+ 
+ /* Number of channels in group */
+ #define MLXPLAT_CPLD_GRP_CHNL_NUM		8
+@@ -138,9 +143,10 @@
+ /* Start channel numbers */
+ #define MLXPLAT_CPLD_CH1			2
+ #define MLXPLAT_CPLD_CH2			10
++#define MLXPLAT_CPLD_CH3			18
+ 
+ /* Number of LPC attached MUX platform devices */
+-#define MLXPLAT_CPLD_LPC_MUX_DEVS		2
++#define MLXPLAT_CPLD_LPC_MUX_DEVS		3
+ 
+ /* Hotplug devices adapter numbers */
+ #define MLXPLAT_CPLD_NR_NONE			-1
+@@ -221,7 +227,7 @@ static const int mlxplat_default_channels[][MLXPLAT_CPLD_GRP_CHNL_NUM] = {
+ static const int mlxplat_msn21xx_channels[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+ 
+ /* Platform mux data */
+-static struct i2c_mux_reg_platform_data mlxplat_mux_data[] = {
++static struct i2c_mux_reg_platform_data mlxplat_default_mux_data[] = {
+ 	{
+ 		.parent = 1,
+ 		.base_nr = MLXPLAT_CPLD_CH1,
+@@ -241,6 +247,40 @@ static struct i2c_mux_reg_platform_data mlxplat_mux_data[] = {
+ 
+ };
+ 
++/* Platform mux configuration variables */
++static int mlxplat_max_adap_num;
++static int mlxplat_mux_num;
++static struct i2c_mux_reg_platform_data *mlxplat_mux_data;
++
++/* Platform extended mux data */
++static struct i2c_mux_reg_platform_data mlxplat_extended_mux_data[] = {
++	{
++		.parent = 1,
++		.base_nr = MLXPLAT_CPLD_CH1,
++		.write_only = 1,
++		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG1,
++		.reg_size = 1,
++		.idle_in_use = 1,
++	},
++	{
++		.parent = 1,
++		.base_nr = MLXPLAT_CPLD_CH2,
++		.write_only = 1,
++		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG3,
++		.reg_size = 1,
++		.idle_in_use = 1,
++	},
++	{
++		.parent = 1,
++		.base_nr = MLXPLAT_CPLD_CH3,
++		.write_only = 1,
++		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG2,
++		.reg_size = 1,
++		.idle_in_use = 1,
++	},
++
++};
++
+ /* Platform hotplug devices */
+ static struct i2c_board_info mlxplat_mlxcpld_psu[] = {
+ 	{
+@@ -1037,6 +1077,80 @@ static struct mlxreg_core_platform_data mlxplat_default_ng_led_data = {
+ 		.counter = ARRAY_SIZE(mlxplat_mlxcpld_default_ng_led_data),
+ };
+ 
++/* Platform led for Comex based 100GbE systems */
++static struct mlxreg_core_data mlxplat_mlxcpld_comex_100G_led_data[] = {
++	{
++		.label = "status:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED1_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++	},
++	{
++		.label = "status:red",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED1_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK
++	},
++	{
++		.label = "psu:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED1_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
++	},
++	{
++		.label = "psu:red",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED1_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
++	},
++	{
++		.label = "fan1:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED2_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++	},
++	{
++		.label = "fan1:red",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED2_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++	},
++	{
++		.label = "fan2:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED2_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
++	},
++	{
++		.label = "fan2:red",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED2_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
++	},
++	{
++		.label = "fan3:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED3_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++	},
++	{
++		.label = "fan3:red",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED3_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++	},
++	{
++		.label = "fan4:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED3_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
++	},
++	{
++		.label = "fan4:red",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED3_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
++	},
++	{
++		.label = "uid:blue",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED5_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++	},
++};
++
++static struct mlxreg_core_platform_data mlxplat_comex_100G_led_data = {
++		.data = mlxplat_mlxcpld_comex_100G_led_data,
++		.counter = ARRAY_SIZE(mlxplat_mlxcpld_comex_100G_led_data),
++};
++
+ /* Platform register access default */
+ static struct mlxreg_core_data mlxplat_mlxcpld_default_regs_io_data[] = {
+ 	{
+@@ -1661,6 +1775,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_AGGR_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRLO_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRCO_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PSU_EVENT_OFFSET:
+@@ -1710,6 +1825,8 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRLO_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRCO_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRCO_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_AGGRCX_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
+@@ -1779,6 +1896,8 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRLO_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRCO_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRCO_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_AGGRCX_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
+@@ -1920,7 +2039,10 @@ static int __init mlxplat_dmi_default_matched(const struct dmi_system_id *dmi)
+ {
+ 	int i;
+ 
+-	for (i = 0; i < ARRAY_SIZE(mlxplat_mux_data); i++) {
++	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
++	mlxplat_mux_num = ARRAY_SIZE(mlxplat_default_mux_data);
++	mlxplat_mux_data = mlxplat_default_mux_data;
++	for (i = 0; i < mlxplat_mux_num; i++) {
+ 		mlxplat_mux_data[i].values = mlxplat_default_channels[i];
+ 		mlxplat_mux_data[i].n_values =
+ 				ARRAY_SIZE(mlxplat_default_channels[i]);
+@@ -1933,13 +2055,16 @@ static int __init mlxplat_dmi_default_matched(const struct dmi_system_id *dmi)
+ 	mlxplat_wd_data[0] = &mlxplat_mlxcpld_wd_set_type1[0];
+ 
+ 	return 1;
+-};
++}
+ 
+ static int __init mlxplat_dmi_msn21xx_matched(const struct dmi_system_id *dmi)
+ {
+ 	int i;
+ 
+-	for (i = 0; i < ARRAY_SIZE(mlxplat_mux_data); i++) {
++	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
++	mlxplat_mux_num = ARRAY_SIZE(mlxplat_default_mux_data);
++	mlxplat_mux_data = mlxplat_default_mux_data;
++	for (i = 0; i < mlxplat_mux_num; i++) {
+ 		mlxplat_mux_data[i].values = mlxplat_msn21xx_channels;
+ 		mlxplat_mux_data[i].n_values =
+ 				ARRAY_SIZE(mlxplat_msn21xx_channels);
+@@ -1952,13 +2077,16 @@ static int __init mlxplat_dmi_msn21xx_matched(const struct dmi_system_id *dmi)
+ 	mlxplat_wd_data[0] = &mlxplat_mlxcpld_wd_set_type1[0];
+ 
+ 	return 1;
+-};
++}
+ 
+ static int __init mlxplat_dmi_msn274x_matched(const struct dmi_system_id *dmi)
+ {
+ 	int i;
+ 
+-	for (i = 0; i < ARRAY_SIZE(mlxplat_mux_data); i++) {
++	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
++	mlxplat_mux_num = ARRAY_SIZE(mlxplat_default_mux_data);
++	mlxplat_mux_data = mlxplat_default_mux_data;
++	for (i = 0; i < mlxplat_mux_num; i++) {
+ 		mlxplat_mux_data[i].values = mlxplat_msn21xx_channels;
+ 		mlxplat_mux_data[i].n_values =
+ 				ARRAY_SIZE(mlxplat_msn21xx_channels);
+@@ -1971,13 +2099,16 @@ static int __init mlxplat_dmi_msn274x_matched(const struct dmi_system_id *dmi)
+ 	mlxplat_wd_data[0] = &mlxplat_mlxcpld_wd_set_type1[0];
+ 
+ 	return 1;
+-};
++}
+ 
+ static int __init mlxplat_dmi_msn201x_matched(const struct dmi_system_id *dmi)
+ {
+ 	int i;
+ 
+-	for (i = 0; i < ARRAY_SIZE(mlxplat_mux_data); i++) {
++	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
++	mlxplat_mux_num = ARRAY_SIZE(mlxplat_default_mux_data);
++	mlxplat_mux_data = mlxplat_default_mux_data;
++	for (i = 0; i < mlxplat_mux_num; i++) {
+ 		mlxplat_mux_data[i].values = mlxplat_msn21xx_channels;
+ 		mlxplat_mux_data[i].n_values =
+ 				ARRAY_SIZE(mlxplat_msn21xx_channels);
+@@ -1990,13 +2121,16 @@ static int __init mlxplat_dmi_msn201x_matched(const struct dmi_system_id *dmi)
+ 	mlxplat_wd_data[0] = &mlxplat_mlxcpld_wd_set_type1[0];
+ 
+ 	return 1;
+-};
++}
+ 
+ static int __init mlxplat_dmi_qmb7xx_matched(const struct dmi_system_id *dmi)
+ {
+ 	int i;
+ 
+-	for (i = 0; i < ARRAY_SIZE(mlxplat_mux_data); i++) {
++	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
++	mlxplat_mux_num = ARRAY_SIZE(mlxplat_default_mux_data);
++	mlxplat_mux_data = mlxplat_default_mux_data;
++	for (i = 0; i < mlxplat_mux_num; i++) {
+ 		mlxplat_mux_data[i].values = mlxplat_msn21xx_channels;
+ 		mlxplat_mux_data[i].n_values =
+ 				ARRAY_SIZE(mlxplat_msn21xx_channels);
+@@ -2013,27 +2147,31 @@ static int __init mlxplat_dmi_qmb7xx_matched(const struct dmi_system_id *dmi)
+ 	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_ng;
+ 
+ 	return 1;
+-};
++}
+ 
+ static int __init mlxplat_dmi_comex_matched(const struct dmi_system_id *dmi)
+ {
+ 	int i;
+ 
+-	for (i = 0; i < ARRAY_SIZE(mlxplat_mux_data); i++) {
++	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_EXT_ADAPTER_NUM;
++	mlxplat_mux_num = ARRAY_SIZE(mlxplat_extended_mux_data);
++	mlxplat_mux_data = mlxplat_extended_mux_data;
++	for (i = 0; i < mlxplat_mux_num; i++) {
+ 		mlxplat_mux_data[i].values = mlxplat_msn21xx_channels;
+ 		mlxplat_mux_data[i].n_values =
+ 				ARRAY_SIZE(mlxplat_msn21xx_channels);
+ 	}
+ 	mlxplat_hotplug = &mlxplat_mlxcpld_comex_data;
+-	mlxplat_hotplug->deferred_nr =
+-			mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
+-	mlxplat_led = &mlxplat_default_led_data;
+-	mlxplat_regs_io = &mlxplat_default_regs_io_data;
++	mlxplat_hotplug->deferred_nr = MLXPLAT_CPLD_MAX_PHYS_EXT_ADAPTER_NUM;
++	mlxplat_led = &mlxplat_comex_100G_led_data;
++	mlxplat_regs_io = &mlxplat_default_ng_regs_io_data;
+ 	mlxplat_fan = &mlxplat_default_fan_data;
++	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)
++		mlxplat_wd_data[i] = &mlxplat_mlxcpld_wd_set_type2[i];
+ 	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_comex;
+ 
+ 	return 1;
+-};
++}
+ 
+ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 	{
+@@ -2168,7 +2306,7 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
+ 	/* Scan adapters from expected id to verify it is free. */
+ 	*nr = MLXPLAT_CPLD_PHYS_ADAPTER_DEF_NR;
+ 	for (i = MLXPLAT_CPLD_PHYS_ADAPTER_DEF_NR; i <
+-	     MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM; i++) {
++	     mlxplat_max_adap_num; i++) {
+ 		search_adap = i2c_get_adapter(i);
+ 		if (search_adap) {
+ 			i2c_put_adapter(search_adap);
+@@ -2182,12 +2320,12 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
+ 	}
+ 
+ 	/* Return with error if free id for adapter is not found. */
+-	if (i == MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM)
++	if (i == mlxplat_max_adap_num)
+ 		return -ENODEV;
+ 
+ 	/* Shift adapter ids, since expected parent adapter is not free. */
+ 	*nr = i;
+-	for (i = 0; i < ARRAY_SIZE(mlxplat_mux_data); i++) {
++	for (i = 0; i < mlxplat_mux_num; i++) {
+ 		shift = *nr - mlxplat_mux_data[i].parent;
+ 		mlxplat_mux_data[i].parent = *nr;
+ 		mlxplat_mux_data[i].base_nr += shift;
+@@ -2243,7 +2381,7 @@ static int __init mlxplat_init(void)
+ 	if (nr < 0)
+ 		goto fail_alloc;
+ 
+-	nr = (nr == MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM) ? -1 : nr;
++	nr = (nr == mlxplat_max_adap_num) ? -1 : nr;
+ 	if (mlxplat_i2c)
+ 		mlxplat_i2c->regmap = priv->regmap;
+ 	priv->pdev_i2c = platform_device_register_resndata(
+@@ -2256,7 +2394,7 @@ static int __init mlxplat_init(void)
+ 		goto fail_alloc;
+ 	}
+ 
+-	for (i = 0; i < ARRAY_SIZE(mlxplat_mux_data); i++) {
++	for (i = 0; i < mlxplat_mux_num; i++) {
+ 		priv->pdev_mux[i] = platform_device_register_resndata(
+ 						&priv->pdev_i2c->dev,
+ 						"i2c-mux-reg", i, NULL,
+@@ -2381,10 +2519,8 @@ static void __exit mlxplat_exit(void)
+ 	struct mlxplat_priv *priv = platform_get_drvdata(mlxplat_dev);
+ 	int i;
+ 
+-	for (i = MLXPLAT_CPLD_WD_MAX_DEVS - 1; i >= 0 ; i--) {
+-		if (mlxplat_wd_data[i])
+-			platform_device_unregister(priv->pdev_wd[i]);
+-	}
++	for (i = MLXPLAT_CPLD_WD_MAX_DEVS - 1; i >= 0 ; i--)
++		platform_device_unregister(priv->pdev_wd[i]);
+ 	if (priv->pdev_fan)
+ 		platform_device_unregister(priv->pdev_fan);
+ 	if (priv->pdev_io_regs)
+@@ -2392,7 +2528,7 @@ static void __exit mlxplat_exit(void)
+ 	platform_device_unregister(priv->pdev_led);
+ 	platform_device_unregister(priv->pdev_hotplug);
+ 
+-	for (i = ARRAY_SIZE(mlxplat_mux_data) - 1; i >= 0 ; i--)
++	for (i = mlxplat_mux_num - 1; i >= 0 ; i--)
+ 		platform_device_unregister(priv->pdev_mux[i]);
+ 
+ 	platform_device_unregister(priv->pdev_i2c);
+-- 
+2.11.0
+

--- a/patch/0055-platform-x86-mlx-platform-Add-support-for-next-gener.patch
+++ b/patch/0055-platform-x86-mlx-platform-Add-support-for-next-gener.patch
@@ -1,0 +1,486 @@
+From 4da715b3bea946b1f9d43a7c95c54be4dcb057f2 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Thu, 2 Jan 2020 06:58:09 +0000
+Subject: [PATCH platform] platform/x86: mlx-platform: Add support for next
+ generation systems
+
+Add support for new Mellanox system types of basic class VMOD0010,
+containing new Mellanox systems equipped with new switch device
+Spectrum 3 (32x400GbE/64x200G/128x100G Ethernet switch).
+These are the Top of the Rack 1U/2U/4U systems, equipped with
+Mellanox Comex card and with the switch board with Mellanox Spectrum-3
+device.
+This class of devices can be equipped with two PS units for 1U/2U or
+with four PS units for 4U systems.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/platform/mellanox/mlxreg-hotplug.c |  14 ++
+ drivers/platform/x86/mlx-platform.c        | 265 +++++++++++++++++++++++++++++
+ include/linux/platform_data/mlxreg.h       |   2 +
+ 3 files changed, 281 insertions(+)
+
+diff --git a/drivers/platform/mellanox/mlxreg-hotplug.c b/drivers/platform/mellanox/mlxreg-hotplug.c
+index f85a1b9d129b..bd34aac2426e 100644
+--- a/drivers/platform/mellanox/mlxreg-hotplug.c
++++ b/drivers/platform/mellanox/mlxreg-hotplug.c
+@@ -504,6 +504,20 @@ static int mlxreg_hotplug_set_irq(struct mlxreg_hotplug_priv_data *priv)
+ 	item = pdata->items;
+ 
+ 	for (i = 0; i < pdata->counter; i++, item++) {
++		if (item->capability) {
++			/*
++			 * Read group capability register to get actual number
++			 * of interrupt capable components and set group mask
++			 * accordingly.
++			 */
++			ret = regmap_read(priv->regmap, item->capability,
++					  &regval);
++			if (ret)
++				goto out;
++
++			item->mask = GENMASK((regval & item->mask) - 1, 0);
++		}
++
+ 		/* Clear group presense event. */
+ 		ret = regmap_write(priv->regmap, item->reg +
+ 				   MLXREG_HOTPLUG_EVENT_OFF, 0);
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index 1a4fecb770ad..c27548fd386a 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -35,6 +35,8 @@
+ #define MLXPLAT_CPLD_LPC_REG_LED4_OFFSET	0x23
+ #define MLXPLAT_CPLD_LPC_REG_LED5_OFFSET	0x24
+ #define MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION	0x2a
++#define MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET	0x2b
++#define MLXPLAT_CPLD_LPC_REG_GP0_OFFSET		0x2e
+ #define MLXPLAT_CPLD_LPC_REG_GP1_OFFSET		0x30
+ #define MLXPLAT_CPLD_LPC_REG_WP1_OFFSET		0x31
+ #define MLXPLAT_CPLD_LPC_REG_GP2_OFFSET		0x32
+@@ -70,6 +72,7 @@
+ #define MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET	0xd1
+ #define MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET	0xd2
+ #define MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET	0xd3
++#define MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET	0xe2
+ #define MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET	0xe3
+ #define MLXPLAT_CPLD_LPC_REG_TACHO1_OFFSET	0xe4
+ #define MLXPLAT_CPLD_LPC_REG_TACHO2_OFFSET	0xe5
+@@ -87,6 +90,9 @@
+ #define MLXPLAT_CPLD_LPC_REG_FAN_CAP2_OFFSET	0xf6
+ #define MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET	0xf7
+ #define MLXPLAT_CPLD_LPC_REG_TACHO_SPEED_OFFSET	0xf8
++#define MLXPLAT_CPLD_LPC_REG_PSU_I2C_CAP_OFFSET 0xf9
++#define MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET	0xfb
++#define MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET	0xfc
+ #define MLXPLAT_CPLD_LPC_IO_RANGE		0x100
+ #define MLXPLAT_CPLD_LPC_I2C_CH1_OFF		0xdb
+ #define MLXPLAT_CPLD_LPC_I2C_CH2_OFF		0xda
+@@ -118,11 +124,16 @@
+ #define MLXPLAT_CPLD_LOW_AGGR_MASK_I2C	BIT(6)
+ #define MLXPLAT_CPLD_PSU_MASK		GENMASK(1, 0)
+ #define MLXPLAT_CPLD_PWR_MASK		GENMASK(1, 0)
++#define MLXPLAT_CPLD_PSU_EXT_MASK	GENMASK(3, 0)
++#define MLXPLAT_CPLD_PWR_EXT_MASK	GENMASK(3, 0)
+ #define MLXPLAT_CPLD_FAN_MASK		GENMASK(3, 0)
+ #define MLXPLAT_CPLD_ASIC_MASK		GENMASK(1, 0)
+ #define MLXPLAT_CPLD_FAN_NG_MASK	GENMASK(5, 0)
+ #define MLXPLAT_CPLD_LED_LO_NIBBLE_MASK	GENMASK(7, 4)
+ #define MLXPLAT_CPLD_LED_HI_NIBBLE_MASK	GENMASK(3, 0)
++#define MLXPLAT_CPLD_VOLTREG_UPD_MASK	GENMASK(5, 4)
++#define MLXPLAT_CPLD_I2C_CAP_BIT	0x04
++#define MLXPLAT_CPLD_I2C_CAP_MASK	GENMASK(5, MLXPLAT_CPLD_I2C_CAP_BIT)
+ 
+ /* Masks for aggregation for comex carriers */
+ #define MLXPLAT_CPLD_AGGR_MASK_CARRIER	BIT(1)
+@@ -152,6 +163,7 @@
+ #define MLXPLAT_CPLD_NR_NONE			-1
+ #define MLXPLAT_CPLD_PSU_DEFAULT_NR		10
+ #define MLXPLAT_CPLD_PSU_MSNXXXX_NR		4
++#define MLXPLAT_CPLD_PSU_MSNXXXX_NR2		3
+ #define MLXPLAT_CPLD_FAN1_DEFAULT_NR		11
+ #define MLXPLAT_CPLD_FAN2_DEFAULT_NR		12
+ #define MLXPLAT_CPLD_FAN3_DEFAULT_NR		13
+@@ -201,8 +213,24 @@ static const struct resource mlxplat_lpc_resources[] = {
+ 			       IORESOURCE_IO),
+ };
+ 
++/* Platform i2c next generation systems data */
++static struct mlxreg_core_data mlxplat_mlxcpld_i2c_ng_items_data[] = {
++	{
++		.reg = MLXPLAT_CPLD_LPC_REG_PSU_I2C_CAP_OFFSET,
++		.mask = MLXPLAT_CPLD_I2C_CAP_MASK,
++		.bit = MLXPLAT_CPLD_I2C_CAP_BIT,
++	},
++};
++
++static struct mlxreg_core_item mlxplat_mlxcpld_i2c_ng_items[] = {
++	{
++		.data = mlxplat_mlxcpld_i2c_ng_items_data,
++	},
++};
++
+ /* Platform next generation systems i2c data */
+ static struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_i2c_ng_data = {
++	.items = mlxplat_mlxcpld_i2c_ng_items,
+ 	.cell = MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET,
+ 	.mask = MLXPLAT_CPLD_AGGR_MASK_COMEX,
+ 	.cell_low = MLXPLAT_CPLD_LPC_REG_AGGRCO_OFFSET,
+@@ -836,6 +864,116 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_default_ng_data = {
+ 	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW,
+ };
+ 
++/* Platform hotplug extended system family data */
++static struct mlxreg_core_data mlxplat_mlxcpld_ext_psu_items_data[] = {
++	{
++		.label = "psu1",
++		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
++		.mask = BIT(0),
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
++	},
++	{
++		.label = "psu2",
++		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
++		.mask = BIT(1),
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
++	},
++	{
++		.label = "psu3",
++		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
++		.mask = BIT(2),
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
++	},
++	{
++		.label = "psu4",
++		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
++		.mask = BIT(3),
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
++	},
++};
++
++static struct mlxreg_core_data mlxplat_mlxcpld_ext_pwr_items_data[] = {
++	{
++		.label = "pwr1",
++		.reg = MLXPLAT_CPLD_LPC_REG_PWR_OFFSET,
++		.mask = BIT(0),
++		.hpdev.brdinfo = &mlxplat_mlxcpld_pwr[0],
++		.hpdev.nr = MLXPLAT_CPLD_PSU_MSNXXXX_NR,
++	},
++	{
++		.label = "pwr2",
++		.reg = MLXPLAT_CPLD_LPC_REG_PWR_OFFSET,
++		.mask = BIT(1),
++		.hpdev.brdinfo = &mlxplat_mlxcpld_pwr[1],
++		.hpdev.nr = MLXPLAT_CPLD_PSU_MSNXXXX_NR,
++	},
++	{
++		.label = "pwr3",
++		.reg = MLXPLAT_CPLD_LPC_REG_PWR_OFFSET,
++		.mask = BIT(2),
++		.hpdev.brdinfo = &mlxplat_mlxcpld_pwr[0],
++		.hpdev.nr = MLXPLAT_CPLD_PSU_MSNXXXX_NR2,
++	},
++	{
++		.label = "pwr4",
++		.reg = MLXPLAT_CPLD_LPC_REG_PWR_OFFSET,
++		.mask = BIT(3),
++		.hpdev.brdinfo = &mlxplat_mlxcpld_pwr[1],
++		.hpdev.nr = MLXPLAT_CPLD_PSU_MSNXXXX_NR2,
++	},
++};
++
++static struct mlxreg_core_item mlxplat_mlxcpld_ext_items[] = {
++	{
++		.data = mlxplat_mlxcpld_ext_psu_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
++		.mask = MLXPLAT_CPLD_PSU_EXT_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_PSU_I2C_CAP_OFFSET,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_ext_psu_items_data),
++		.inversed = 1,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_ext_pwr_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_PWR_OFFSET,
++		.mask = MLXPLAT_CPLD_PWR_EXT_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_PSU_I2C_CAP_OFFSET,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_ext_pwr_items_data),
++		.inversed = 0,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_default_ng_fan_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_FAN_OFFSET,
++		.mask = MLXPLAT_CPLD_FAN_NG_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_default_ng_fan_items_data),
++		.inversed = 1,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_default_asic_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_default_asic_items_data),
++		.inversed = 0,
++		.health = true,
++	},
++};
++
++static
++struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_ext_data = {
++	.items = mlxplat_mlxcpld_ext_items,
++	.counter = ARRAY_SIZE(mlxplat_mlxcpld_ext_items),
++	.cell = MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET,
++	.mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF | MLXPLAT_CPLD_AGGR_MASK_COMEX,
++	.cell_low = MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET,
++	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW,
++};
++
+ /* Platform led default data */
+ static struct mlxreg_core_data mlxplat_mlxcpld_default_led_data[] = {
+ 	{
+@@ -1344,6 +1482,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_msn21xx_regs_io_data[] = {
+ 		.mode = 0200,
+ 	},
+ 	{
++		.label = "select_iio",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(6),
++		.mode = 0644,
++	},
++	{
+ 		.label = "asic_health",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
+ 		.mask = MLXPLAT_CPLD_ASIC_MASK,
+@@ -1432,6 +1576,18 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mode = 0444,
+ 	},
+ 	{
++		.label = "reset_platform",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(4),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_soc",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(5),
++		.mode = 0444,
++	},
++	{
+ 		.label = "reset_comex_wd",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(6),
+@@ -1468,6 +1624,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mode = 0444,
+ 	},
+ 	{
++		.label = "reset_ac_pwr_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(6),
++		.mode = 0444,
++	},
++	{
+ 		.label = "psu1_on",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(0),
+@@ -1510,6 +1672,43 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.bit = GENMASK(7, 0),
+ 		.mode = 0444,
+ 	},
++	{
++		.label = "voltreg_update_status",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET,
++		.mask = MLXPLAT_CPLD_VOLTREG_UPD_MASK,
++		.bit = 5,
++		.mode = 0444,
++	},
++	{
++		.label = "vpd_wp",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP0_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(3),
++		.mode = 0644,
++	},
++	{
++		.label = "pcie_asic_reset_dis",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP0_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(4),
++		.mode = 0644,
++	},
++	{
++		.label = "config1",
++		.reg = MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "config2",
++		.reg = MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "ufm_version",
++		.reg = MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
+ };
+ 
+ static struct mlxreg_core_platform_data mlxplat_default_ng_regs_io_data = {
+@@ -1768,6 +1967,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_LED3_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LED4_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LED5_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_GP0_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_GP1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WP1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_GP2_OFFSET:
+@@ -1815,6 +2015,8 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_LED4_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LED5_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION:
++	case MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_GP0_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_GP1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WP1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_GP2_OFFSET:
+@@ -1867,6 +2069,10 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_FAN_CAP2_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_TACHO_SPEED_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_PSU_I2C_CAP_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET:
+ 		return true;
+ 	}
+ 	return false;
+@@ -1888,6 +2094,8 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_LED4_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LED5_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION:
++	case MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_GP0_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_GP1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_GP2_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET:
+@@ -1932,6 +2140,10 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_FAN_CAP2_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_TACHO_SPEED_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_PSU_I2C_CAP_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET:
+ 		return true;
+ 	}
+ 	return false;
+@@ -1955,6 +2167,13 @@ static const struct reg_default mlxplat_mlxcpld_regmap_comex_default[] = {
+ 	{ MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET, 0x00 },
+ };
+ 
++static const struct reg_default mlxplat_mlxcpld_regmap_ng400[] = {
++	{ MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET, 0x00 },
++	{ MLXPLAT_CPLD_LPC_REG_WD1_ACT_OFFSET, 0x00 },
++	{ MLXPLAT_CPLD_LPC_REG_WD2_ACT_OFFSET, 0x00 },
++	{ MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET, 0x00 },
++};
++
+ struct mlxplat_mlxcpld_regmap_context {
+ 	void __iomem *base;
+ };
+@@ -2021,6 +2240,20 @@ static const struct regmap_config mlxplat_mlxcpld_regmap_config_comex = {
+ 	.reg_write = mlxplat_mlxcpld_reg_write,
+ };
+ 
++static const struct regmap_config mlxplat_mlxcpld_regmap_config_ng400 = {
++	.reg_bits = 8,
++	.val_bits = 8,
++	.max_register = 255,
++	.cache_type = REGCACHE_FLAT,
++	.writeable_reg = mlxplat_mlxcpld_writeable_reg,
++	.readable_reg = mlxplat_mlxcpld_readable_reg,
++	.volatile_reg = mlxplat_mlxcpld_volatile_reg,
++	.reg_defaults = mlxplat_mlxcpld_regmap_ng400,
++	.num_reg_defaults = ARRAY_SIZE(mlxplat_mlxcpld_regmap_ng400),
++	.reg_read = mlxplat_mlxcpld_reg_read,
++	.reg_write = mlxplat_mlxcpld_reg_write,
++};
++
+ static struct resource mlxplat_mlxcpld_resources[] = {
+ 	[0] = DEFINE_RES_IRQ_NAMED(17, "mlxreg-hotplug"),
+ };
+@@ -2173,6 +2406,32 @@ static int __init mlxplat_dmi_comex_matched(const struct dmi_system_id *dmi)
+ 	return 1;
+ }
+ 
++static int __init mlxplat_dmi_ng400_matched(const struct dmi_system_id *dmi)
++{
++	int i;
++
++	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
++	mlxplat_mux_num = ARRAY_SIZE(mlxplat_default_mux_data);
++	mlxplat_mux_data = mlxplat_default_mux_data;
++	for (i = 0; i < mlxplat_mux_num; i++) {
++		mlxplat_mux_data[i].values = mlxplat_msn21xx_channels;
++		mlxplat_mux_data[i].n_values =
++				ARRAY_SIZE(mlxplat_msn21xx_channels);
++	}
++	mlxplat_hotplug = &mlxplat_mlxcpld_ext_data;
++	mlxplat_hotplug->deferred_nr =
++		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
++	mlxplat_led = &mlxplat_default_ng_led_data;
++	mlxplat_regs_io = &mlxplat_default_ng_regs_io_data;
++	mlxplat_fan = &mlxplat_default_fan_data;
++	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)
++		mlxplat_wd_data[i] = &mlxplat_mlxcpld_wd_set_type2[i];
++	mlxplat_i2c = &mlxplat_mlxcpld_i2c_ng_data;
++	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_ng400;
++
++	return 1;
++}
++
+ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 	{
+ 		.callback = mlxplat_dmi_default_matched,
+@@ -2217,6 +2476,12 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 		},
+ 	},
+ 	{
++		.callback = mlxplat_dmi_ng400_matched,
++		.matches = {
++			DMI_MATCH(DMI_BOARD_NAME, "VMOD0010"),
++		},
++	},
++	{
+ 		.callback = mlxplat_dmi_msn274x_matched,
+ 		.matches = {
+ 			DMI_MATCH(DMI_BOARD_VENDOR, "Mellanox Technologies"),
+diff --git a/include/linux/platform_data/mlxreg.h b/include/linux/platform_data/mlxreg.h
+index 6d54fe3bcac9..b8da8aef2446 100644
+--- a/include/linux/platform_data/mlxreg.h
++++ b/include/linux/platform_data/mlxreg.h
+@@ -101,6 +101,7 @@ struct mlxreg_core_data {
+  * @aggr_mask: group aggregation mask;
+  * @reg: group interrupt status register;
+  * @mask: group interrupt mask;
++ * @capability: group capability register;
+  * @cache: last status value for elements fro the same group;
+  * @count: number of available elements in the group;
+  * @ind: element's index inside the group;
+@@ -112,6 +113,7 @@ struct mlxreg_core_item {
+ 	u32 aggr_mask;
+ 	u32 reg;
+ 	u32 mask;
++	u32 capability;
+ 	u32 cache;
+ 	u8 count;
+ 	u8 ind;
+-- 
+2.11.0
+

--- a/patch/0056-mlxsw-core-Add-support-for-new-hardware-device-types.patch
+++ b/patch/0056-mlxsw-core-Add-support-for-new-hardware-device-types.patch
@@ -1,0 +1,87 @@
+From 78c5e6e6d39427868a33d86cc83c1646503a1d78 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Thu, 23 Jan 2020 20:17:36 +0000
+Subject: [PATCH mlxsw] mlxsw: core: Add support for new hardware device types
+
+Add validation for new device types, provided by MGPIR
+register.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c   | 6 ++++--
+ drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 8 ++++++--
+ drivers/net/ethernet/mellanox/mlxsw/reg.h          | 3 +++
+ 3 files changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c b/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
+index 9cb19ec47e4d..cd1d371edfcf 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
+@@ -575,6 +575,7 @@ static int mlxsw_hwmon_module_init(struct mlxsw_hwmon *mlxsw_hwmon)
+ 
+ static int mlxsw_hwmon_gearbox_init(struct mlxsw_hwmon *mlxsw_hwmon)
+ {
++	enum mlxsw_reg_mgpir_device_type device_type;
+ 	int index, max_index, sensor_index;
+ 	char mgpir_pl[MLXSW_REG_MGPIR_LEN];
+ 	char mtmp_pl[MLXSW_REG_MTMP_LEN];
+@@ -586,8 +587,9 @@ static int mlxsw_hwmon_gearbox_init(struct mlxsw_hwmon *mlxsw_hwmon)
+ 	if (err)
+ 		return 0;
+ 
+-	mlxsw_reg_mgpir_unpack(mgpir_pl, &gbox_num, NULL, NULL, NULL);
+-	if (!gbox_num)
++	mlxsw_reg_mgpir_unpack(mgpir_pl, &gbox_num, &device_type, NULL, NULL);
++	if ((device_type != MLXSW_REG_MGPIR_DEVICE_TYPE_GEARBOX_DIE) ||
++	    !gbox_num)
+ 		return 0;
+ 
+ 	index = mlxsw_hwmon->module_sensor_count;
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+index f234416305fd..690ae0f1820e 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+@@ -920,8 +920,10 @@ static int
+ mlxsw_thermal_gearboxes_init(struct device *dev, struct mlxsw_core *core,
+ 			     struct mlxsw_thermal *thermal)
+ {
++	enum mlxsw_reg_mgpir_device_type device_type;
+ 	struct mlxsw_thermal_module *gearbox_tz;
+ 	char mgpir_pl[MLXSW_REG_MGPIR_LEN];
++	u8 num_of_device;
+ 	int i;
+ 	int err;
+ 
+@@ -933,11 +935,13 @@ mlxsw_thermal_gearboxes_init(struct device *dev, struct mlxsw_core *core,
+ 	if (err)
+ 		return 0;
+ 
+-	mlxsw_reg_mgpir_unpack(mgpir_pl, &thermal->tz_gearbox_num, NULL, NULL,
++	mlxsw_reg_mgpir_unpack(mgpir_pl, &num_of_device, &device_type, NULL,
+ 			       NULL);
+-	if (!thermal->tz_gearbox_num)
++	if ((device_type != MLXSW_REG_MGPIR_DEVICE_TYPE_GEARBOX_DIE) ||
++	    !num_of_device)
+ 		return 0;
+ 
++	thermal->tz_gearbox_num = num_of_device;
+ 	thermal->tz_gearbox_arr = kcalloc(thermal->tz_gearbox_num,
+ 					  sizeof(*thermal->tz_gearbox_arr),
+ 					  GFP_KERNEL);
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/reg.h b/drivers/net/ethernet/mellanox/mlxsw/reg.h
+index 8d7a58472799..43e73701a125 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/reg.h
++++ b/drivers/net/ethernet/mellanox/mlxsw/reg.h
+@@ -8601,6 +8601,9 @@ MLXSW_REG_DEFINE(mgpir, MLXSW_REG_MGPIR_ID, MLXSW_REG_MGPIR_LEN);
+ enum mlxsw_reg_mgpir_device_type {
+ 	MLXSW_REG_MGPIR_DEVICE_TYPE_NONE,
+ 	MLXSW_REG_MGPIR_DEVICE_TYPE_GEARBOX_DIE,
++	MLXSW_REG_MGPIR_DEVICE_TYPE_TILE,
++	MLXSW_REG_MGPIR_DEVICE_TYPE_AGBM,
++	MLXSW_REG_MGPIR_DEVICE_TYPE_XM,
+ };
+ 
+ /* device_type
+-- 
+2.11.0
+

--- a/patch/0057-mlxsw-minimal-Fix-validation-for-FW-minor-version.patch
+++ b/patch/0057-mlxsw-minimal-Fix-validation-for-FW-minor-version.patch
@@ -1,0 +1,32 @@
+From d4689cb7a12bd37ac0ace709b87dd91dd316bfd9 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Mon, 10 Feb 2020 06:44:16 +0000
+Subject: [net] mlxsw: minimal: Fix validation for FW minor version
+
+Fix validation for FW minor version in order to prevent driver initialization
+in case FW minor version is older than expected.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/minimal.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/minimal.c b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
+index 504db124ee2f..8cc969758f2f 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/minimal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
+@@ -127,8 +127,9 @@ static int mlxsw_m_fw_rev_validate(struct mlxsw_m *mlxsw_m)
+ 	dev_info(mlxsw_m->bus_info->dev, "The firmware version %d.%d.%d\n",
+ 		 rev->major, rev->minor, rev->subminor);
+ 	/* Validate driver & FW are compatible */
+-	if (rev->minor >= MLXSW_M_FWREV_MINOR &&
+-	    rev->subminor >= MLXSW_M_FWREV_SUBMINOR)
++	if ((rev->minor > MLXSW_M_FWREV_MINOR) ||
++	    (rev->minor == MLXSW_M_FWREV_MINOR &&
++	     rev->subminor >= MLXSW_M_FWREV_SUBMINOR))
+ 		return 0;
+ 
+ 	dev_info(mlxsw_m->bus_info->dev, "The firmware version %d.%d.%d is incompatible with the driver (required >= %d.%d.%d)\n",
+-- 
+2.11.0
+

--- a/patch/0058-mlxsw-core-thermal-Set-default-thermal-trips-at-init.patch
+++ b/patch/0058-mlxsw-core-thermal-Set-default-thermal-trips-at-init.patch
@@ -1,0 +1,49 @@
+From a50b84e93f743c13f2568396927c7744ff706e29 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Mon, 23 Mar 2020 12:57:16 +0200
+Subject: [thermal_emul 1/2] mlxsw: core: thermal: Set default thermal trips at
+ initialization
+
+Set default thermal trip temperatures during thermal zone
+initialization. Otherwise polling time for thermal control
+could stay zero and such thermal zones will not be triggered by
+thermal algorithm.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+index 690ae0f1820e..53198e260633 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+@@ -20,6 +20,10 @@
+ #define MLXSW_THERMAL_ASIC_TEMP_HIGH	85000	/* 85C */
+ #define MLXSW_THERMAL_ASIC_TEMP_HOT	105000	/* 105C */
+ #define MLXSW_THERMAL_ASIC_TEMP_CRIT	110000	/* 110C */
++#define MLXSW_THERMAL_MODULE_TEMP_NORM	60000	/* 60C */
++#define MLXSW_THERMAL_MODULE_TEMP_HIGH	70000	/* 70C */
++#define MLXSW_THERMAL_MODULE_TEMP_HOT	80000	/* 80C */
++#define MLXSW_THERMAL_MODULE_TEMP_CRIT	90000	/* 90C */
+ #define MLXSW_THERMAL_HYSTERESIS_TEMP	5000	/* 5C */
+ #define MLXSW_THERMAL_MODULE_TEMP_SHIFT	(MLXSW_THERMAL_HYSTERESIS_TEMP * 2)
+ #define MLXSW_THERMAL_ZONE_MAX_NAME	16
+@@ -154,10 +158,10 @@ static int mlxsw_get_cooling_device_idx(struct mlxsw_thermal *thermal,
+ static void
+ mlxsw_thermal_module_trips_reset(struct mlxsw_thermal_module *tz)
+ {
+-	tz->trips[MLXSW_THERMAL_TEMP_TRIP_NORM].temp = 0;
+-	tz->trips[MLXSW_THERMAL_TEMP_TRIP_HIGH].temp = 0;
+-	tz->trips[MLXSW_THERMAL_TEMP_TRIP_HOT].temp = 0;
+-	tz->trips[MLXSW_THERMAL_TEMP_TRIP_CRIT].temp = 0;
++	tz->trips[MLXSW_THERMAL_TEMP_TRIP_NORM].temp = MLXSW_THERMAL_MODULE_TEMP_NORM;
++	tz->trips[MLXSW_THERMAL_TEMP_TRIP_HIGH].temp = MLXSW_THERMAL_MODULE_TEMP_HIGH;
++	tz->trips[MLXSW_THERMAL_TEMP_TRIP_HOT].temp = MLXSW_THERMAL_MODULE_TEMP_HOT;
++	tz->trips[MLXSW_THERMAL_TEMP_TRIP_CRIT].temp = MLXSW_THERMAL_MODULE_TEMP_CRIT;
+ }
+ 
+ static int
+-- 
+2.11.0
+

--- a/patch/0059-mlxsw-core-Add-the-hottest-thermal-zone-detection.patch
+++ b/patch/0059-mlxsw-core-Add-the-hottest-thermal-zone-detection.patch
@@ -1,0 +1,165 @@
+From a975f22abc2b75614f5a58ea8af843043ade782f Mon Sep 17 00:00:00 2001
+From: junchao <junchao@contoso.com>
+Date: Mon, 30 Mar 2020 10:05:25 +0000
+Subject: [hwmon-next 04/14] mlxsw: core: Add the hottest thermal zone
+ detection
+
+When multiple sensors are mapped to the same cooling device, the
+cooling device should be set according the worst sensor from the
+sensors associated with this cooling device.
+
+Provide the hottest thermal zone detection and enforce cooling device
+to follow the temperature trends of the hottest zone only.
+Prevent competition for the cooling device control from others zones,
+by "stable trend" indication. A cooling device will not perform any
+actions associated with a zone with a "stable trend".
+
+When other thermal zone is detected as a hottest, a cooling device is
+to be switched to following temperature trends of new hottest zone.
+
+Thermal zone score is represented by 32 bits unsigned integer and
+calculated according to the next formula:
+For T < TZ<t><i>, where t from {normal trip = 0, high trip = 1, hot
+trip = 2, critical = 3}:
+TZ<i> score = (T + (TZ<t><i> - T) / 2) / (TZ<t><i> - T) * 256 ** j;
+Highest thermal zone score s is set as MAX(TZ<i>score);
+Following this formula, if TZ<i> is in trip point higher than TZ<k>,
+the higher score is to be always assigned to TZ<i>.
+
+For two thermal zones located at the same kind of trip point, the higher
+score will be assigned to the zone which is closer to the next trip
+point. Thus, the highest score will always be assigned objectively to
+the hottest thermal zone.
+
+All the thermal zones initially are to be configured with mode
+"enabled" with the "step_wise" governor.
+
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 55 ++++++++++++++++++++++
+ 1 file changed, 55 insertions(+)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+index e1e18ea..53198e2 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+@@ -27,6 +27,7 @@
+ #define MLXSW_THERMAL_HYSTERESIS_TEMP	5000	/* 5C */
+ #define MLXSW_THERMAL_MODULE_TEMP_SHIFT	(MLXSW_THERMAL_HYSTERESIS_TEMP * 2)
+ #define MLXSW_THERMAL_ZONE_MAX_NAME	16
++#define MLXSW_THERMAL_TEMP_SCORE_MAX	GENMASK(31, 0)
+ #define MLXSW_THERMAL_MAX_STATE	10
+ #define MLXSW_THERMAL_MAX_DUTY	255
+ /* Minimum and maximum fan allowed speed in percent: from 20% to 100%. Values
+@@ -205,6 +206,34 @@ mlxsw_thermal_module_trips_update(struct device *dev, struct mlxsw_core *core,
+ 	return 0;
+ }
+ 
++static void mlxsw_thermal_tz_score_update(struct mlxsw_thermal *thermal,
++					  struct thermal_zone_device *tzdev,
++					  struct mlxsw_thermal_trip *trips,
++					  int temp)
++{
++	struct mlxsw_thermal_trip *trip = trips;
++	unsigned int score, delta, i, shift = 1;
++
++	/* Calculate thermal zone score, if temperature is above the critical
++	 * threshold score is set to MLXSW_THERMAL_TEMP_SCORE_MAX.
++	 */
++	score = MLXSW_THERMAL_TEMP_SCORE_MAX;
++	for (i = MLXSW_THERMAL_TEMP_TRIP_NORM; i < MLXSW_THERMAL_NUM_TRIPS;
++	     i++, trip++) {
++		if (temp < trip->temp) {
++			delta = DIV_ROUND_CLOSEST(temp, trip->temp - temp);
++			score = delta * shift;
++			break;
++		}
++		shift *= 256;
++	}
++
++	if (score > thermal->tz_highest_score) {
++		thermal->tz_highest_score = score;
++		thermal->tz_highest_dev = tzdev;
++	}
++}
++
+ static int mlxsw_thermal_bind(struct thermal_zone_device *tzdev,
+ 			      struct thermal_cooling_device *cdev)
+ {
+@@ -306,6 +335,9 @@ static int mlxsw_thermal_get_temp(struct thermal_zone_device *tzdev,
+ 		return err;
+ 	}
+ 	mlxsw_reg_mtmp_unpack(mtmp_pl, &temp, NULL, NULL);
++	if (temp > 0)
++		mlxsw_thermal_tz_score_update(thermal, tzdev, thermal->trips,
++					      temp);
+ 
+ 	*p_temp = temp;
+ 	return 0;
+@@ -367,6 +399,22 @@ static int mlxsw_thermal_set_trip_hyst(struct thermal_zone_device *tzdev,
+ 	return 0;
+ }
+ 
++static int mlxsw_thermal_trend_get(struct thermal_zone_device *tzdev,
++				   int trip, enum thermal_trend *trend)
++{
++	struct mlxsw_thermal_module *tz = tzdev->devdata;
++	struct mlxsw_thermal *thermal = tz->parent;
++
++	if (trip < 0 || trip >= MLXSW_THERMAL_NUM_TRIPS)
++		return -EINVAL;
++
++	if (tzdev == thermal->tz_highest_dev)
++		return 1;
++
++	*trend = THERMAL_TREND_STABLE;
++	return 0;
++}
++
+ struct thermal_zone_params mlxsw_thermal_params = {
+ 	.no_hwmon = true,
+ };
+@@ -382,6 +430,7 @@ static struct thermal_zone_device_ops mlxsw_thermal_ops = {
+ 	.set_trip_temp	= mlxsw_thermal_set_trip_temp,
+ 	.get_trip_hyst	= mlxsw_thermal_get_trip_hyst,
+ 	.set_trip_hyst	= mlxsw_thermal_set_trip_hyst,
++	.get_trend	= mlxsw_thermal_trend_get,
+ };
+ 
+ static int mlxsw_thermal_module_bind(struct thermal_zone_device *tzdev,
+@@ -499,6 +548,8 @@ static int mlxsw_thermal_module_temp_get(struct thermal_zone_device *tzdev,
+ 
+ 	/* Update trip points. */
+ 	err = mlxsw_thermal_module_trips_update(dev, thermal->core, tz);
++	if (!err && temp > 0)
++		mlxsw_thermal_tz_score_update(thermal, tzdev, tz->trips, temp);
+ 
+ 	return 0;
+ }
+@@ -574,6 +625,7 @@ static struct thermal_zone_device_ops mlxsw_thermal_module_ops = {
+ 	.set_trip_temp	= mlxsw_thermal_module_trip_temp_set,
+ 	.get_trip_hyst	= mlxsw_thermal_module_trip_hyst_get,
+ 	.set_trip_hyst	= mlxsw_thermal_module_trip_hyst_set,
++	.get_trend	= mlxsw_thermal_trend_get,
+ };
+ 
+ static int mlxsw_thermal_gearbox_temp_get(struct thermal_zone_device *tzdev,
+@@ -600,6 +652,8 @@ static int mlxsw_thermal_gearbox_temp_get(struct thermal_zone_device *tzdev,
+ 		return err;
+ 
+ 	mlxsw_reg_mtmp_unpack(mtmp_pl, &temp, NULL, NULL);
++	if (temp > 0)
++		mlxsw_thermal_tz_score_update(thermal, tzdev, tz->trips, temp);
+ 
+ 	*p_temp = temp;
+ 	return 0;
+@@ -616,6 +670,7 @@ static struct thermal_zone_device_ops mlxsw_thermal_gearbox_ops = {
+ 	.set_trip_temp	= mlxsw_thermal_module_trip_temp_set,
+ 	.get_trip_hyst	= mlxsw_thermal_module_trip_hyst_get,
+ 	.set_trip_hyst	= mlxsw_thermal_module_trip_hyst_set,
++	.get_trend	= mlxsw_thermal_trend_get,
+ };
+ 
+ static int mlxsw_thermal_get_max_state(struct thermal_cooling_device *cdev,
+-- 
+2.11.0
+

--- a/patch/0060-hwmon-pmbus-core-Add-support-for-vid-mode-detecti.patch
+++ b/patch/0060-hwmon-pmbus-core-Add-support-for-vid-mode-detecti.patch
@@ -1,0 +1,386 @@
+From 482c5a7b46fd39c2df42c47f96a817c2d50b9c75 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Tue, 3 Mar 2020 14:33:59 +0200
+Subject: [hwmon v1] hwmon: (pmbus/core) Add support for vid mode detection per
+ page bases
+
+Add support for VID protocol detection per page bases, instead of
+detecting it based on PMBU_VOUT readout from page 0.
+The reason that some devices allows to configure different VID modes
+per page within the same device.
+
+Extend "vrm_version" with the type for Intel IMVP9 and AMD 6.25mV VID
+modes.
+Add calculation for those types.
+
+Add support for devices XDPE12254, XDPE12284.
+All these device support two pages.
+The below lists of VOUT_MODE command readout with their related VID
+protocols, Digital to Analog Converter steps, supported by these
+devices:
+VR12.0 mode, 5-mV DAC - 0x01;
+VR12.5 mode, 10-mV DAC - 0x02;
+IMVP9 mode, 5-mV DAC - 0x03;
+AMD mode 6.25mV - 0x10.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/hwmon/pmbus/Kconfig      |   9 +++
+ drivers/hwmon/pmbus/Makefile     |   1 +
+ drivers/hwmon/pmbus/max20751.c   |   2 +-
+ drivers/hwmon/pmbus/pmbus.c      |   5 +-
+ drivers/hwmon/pmbus/pmbus.h      |   4 +-
+ drivers/hwmon/pmbus/pmbus_core.c |  10 ++-
+ drivers/hwmon/pmbus/tps53679.c   |  44 +++++-----
+ drivers/hwmon/pmbus/xdpe12284.c  | 171 +++++++++++++++++++++++++++++++++++++++
+ 8 files changed, 219 insertions(+), 27 deletions(-)
+ create mode 100644 drivers/hwmon/pmbus/xdpe12284.c
+
+diff --git a/drivers/hwmon/pmbus/Kconfig b/drivers/hwmon/pmbus/Kconfig
+index 61938ea22208..79fd67e0c940 100644
+--- a/drivers/hwmon/pmbus/Kconfig
++++ b/drivers/hwmon/pmbus/Kconfig
+@@ -156,6 +156,15 @@ config SENSORS_UCD9200
+ 	  This driver can also be built as a module. If so, the module will
+ 	  be called ucd9200.
+ 
++config SENSORS_XDPE122
++	tristate "Infineon XDPE122 family"
++	help
++	  If you say yes here you get hardware monitoring support for Infineon
++	  XDPE12254, XDPE12284, device.
++
++	  This driver can also be built as a module. If so, the module will
++	  be called xdpe12284.
++
+ config SENSORS_ZL6100
+ 	tristate "Intersil ZL6100 and compatibles"
+ 	default n
+diff --git a/drivers/hwmon/pmbus/Makefile b/drivers/hwmon/pmbus/Makefile
+index b912fec9876d..e0fe17121afb 100644
+--- a/drivers/hwmon/pmbus/Makefile
++++ b/drivers/hwmon/pmbus/Makefile
+@@ -16,4 +16,5 @@ obj-$(CONFIG_SENSORS_TPS40422)	+= tps40422.o
+ obj-$(CONFIG_SENSORS_TPS53679)	+= tps53679.o
+ obj-$(CONFIG_SENSORS_UCD9000)	+= ucd9000.o
+ obj-$(CONFIG_SENSORS_UCD9200)	+= ucd9200.o
++obj-$(CONFIG_SENSORS_XDPE122)	+= xdpe12284.o
+ obj-$(CONFIG_SENSORS_ZL6100)	+= zl6100.o
+diff --git a/drivers/hwmon/pmbus/max20751.c b/drivers/hwmon/pmbus/max20751.c
+index ab74aeae8cf2..394c662c811b 100644
+--- a/drivers/hwmon/pmbus/max20751.c
++++ b/drivers/hwmon/pmbus/max20751.c
+@@ -25,7 +25,7 @@ static struct pmbus_driver_info max20751_info = {
+ 	.pages = 1,
+ 	.format[PSC_VOLTAGE_IN] = linear,
+ 	.format[PSC_VOLTAGE_OUT] = vid,
+-	.vrm_version = vr12,
++	.vrm_version[0] = vr12,
+ 	.format[PSC_TEMPERATURE] = linear,
+ 	.format[PSC_CURRENT_OUT] = linear,
+ 	.format[PSC_POWER] = linear,
+diff --git a/drivers/hwmon/pmbus/pmbus.c b/drivers/hwmon/pmbus/pmbus.c
+index 44ca8a94873d..ad360a88a53a 100644
+--- a/drivers/hwmon/pmbus/pmbus.c
++++ b/drivers/hwmon/pmbus/pmbus.c
+@@ -121,7 +121,7 @@ static int pmbus_identify(struct i2c_client *client,
+ 	}
+ 
+ 	if (pmbus_check_byte_register(client, 0, PMBUS_VOUT_MODE)) {
+-		int vout_mode;
++		int vout_mode, i;
+ 
+ 		vout_mode = pmbus_read_byte_data(client, 0, PMBUS_VOUT_MODE);
+ 		if (vout_mode >= 0 && vout_mode != 0xff) {
+@@ -130,7 +130,8 @@ static int pmbus_identify(struct i2c_client *client,
+ 				break;
+ 			case 1:
+ 				info->format[PSC_VOLTAGE_OUT] = vid;
+-				info->vrm_version = vr11;
++				for (i = 0; i < info->pages; i++)
++					info->vrm_version[i] = vr11;
+ 				break;
+ 			case 2:
+ 				info->format[PSC_VOLTAGE_OUT] = direct;
+diff --git a/drivers/hwmon/pmbus/pmbus.h b/drivers/hwmon/pmbus/pmbus.h
+index 4efa2bd4f6d8..881156491581 100644
+--- a/drivers/hwmon/pmbus/pmbus.h
++++ b/drivers/hwmon/pmbus/pmbus.h
+@@ -341,12 +341,12 @@ enum pmbus_sensor_classes {
+ #define PMBUS_HAVE_STATUS_VMON	BIT(19)
+ 
+ enum pmbus_data_format { linear = 0, direct, vid };
+-enum vrm_version { vr11 = 0, vr12, vr13 };
++enum vrm_version { vr11 = 0, vr12, vr13, imvp9, amd625mv };
+ 
+ struct pmbus_driver_info {
+ 	int pages;		/* Total number of pages */
+ 	enum pmbus_data_format format[PSC_NUM_CLASSES];
+-	enum vrm_version vrm_version;
++	enum vrm_version vrm_version[PMBUS_PAGES]; /* vrm version per page */
+ 	/*
+ 	 * Support one set of coefficients for each sensor type
+ 	 * Used for chips providing data in direct mode.
+diff --git a/drivers/hwmon/pmbus/pmbus_core.c b/drivers/hwmon/pmbus/pmbus_core.c
+index 682b01624908..764a28105831 100644
+--- a/drivers/hwmon/pmbus/pmbus_core.c
++++ b/drivers/hwmon/pmbus/pmbus_core.c
+@@ -522,7 +522,7 @@ static long pmbus_reg2data_vid(struct pmbus_data *data,
+ 	long val = sensor->data;
+ 	long rv = 0;
+ 
+-	switch (data->info->vrm_version) {
++	switch (data->info->vrm_version[sensor->page]) {
+ 	case vr11:
+ 		if (val >= 0x02 && val <= 0xb2)
+ 			rv = DIV_ROUND_CLOSEST(160000 - (val - 2) * 625, 100);
+@@ -535,6 +535,14 @@ static long pmbus_reg2data_vid(struct pmbus_data *data,
+ 		if (val >= 0x01)
+ 			rv = 500 + (val - 1) * 10;
+ 		break;
++	case imvp9:
++		if (val >= 0x01)
++			rv = 200 + (val - 1) * 10;
++		break;
++	case amd625mv:
++		if (val >= 0x0 && val <= 0xd8)
++			rv = DIV_ROUND_CLOSEST(155000 - val * 625, 100);
++		break;
+ 	}
+ 	return rv;
+ }
+diff --git a/drivers/hwmon/pmbus/tps53679.c b/drivers/hwmon/pmbus/tps53679.c
+index 45eacc504e2f..28d3de029b91 100644
+--- a/drivers/hwmon/pmbus/tps53679.c
++++ b/drivers/hwmon/pmbus/tps53679.c
+@@ -33,27 +33,29 @@ static int tps53679_identify(struct i2c_client *client,
+ 			     struct pmbus_driver_info *info)
+ {
+ 	u8 vout_params;
+-	int ret;
+-
+-	/* Read the register with VOUT scaling value.*/
+-	ret = pmbus_read_byte_data(client, 0, PMBUS_VOUT_MODE);
+-	if (ret < 0)
+-		return ret;
+-
+-	vout_params = ret & GENMASK(4, 0);
+-
+-	switch (vout_params) {
+-	case TPS53679_PROT_VR13_10MV:
+-	case TPS53679_PROT_VR12_5_10MV:
+-		info->vrm_version = vr13;
+-		break;
+-	case TPS53679_PROT_VR13_5MV:
+-	case TPS53679_PROT_VR12_5MV:
+-	case TPS53679_PROT_IMVP8_5MV:
+-		info->vrm_version = vr12;
+-		break;
+-	default:
+-		return -EINVAL;
++	int i, ret;
++
++	for (i = 0; i < TPS53679_PAGE_NUM; i++) {
++		/* Read the register with VOUT scaling value.*/
++		ret = pmbus_read_byte_data(client, i, PMBUS_VOUT_MODE);
++		if (ret < 0)
++			return ret;
++
++		vout_params = ret & GENMASK(4, 0);
++
++		switch (vout_params) {
++		case TPS53679_PROT_VR13_10MV:
++		case TPS53679_PROT_VR12_5_10MV:
++			info->vrm_version[i] = vr13;
++			break;
++		case TPS53679_PROT_VR13_5MV:
++		case TPS53679_PROT_VR12_5MV:
++		case TPS53679_PROT_IMVP8_5MV:
++			info->vrm_version[i] = vr12;
++			break;
++		default:
++			return -EINVAL;
++		}
+ 	}
+ 
+ 	return 0;
+diff --git a/drivers/hwmon/pmbus/xdpe12284.c b/drivers/hwmon/pmbus/xdpe12284.c
+new file mode 100644
+index 000000000000..660556b89e9f
+--- /dev/null
++++ b/drivers/hwmon/pmbus/xdpe12284.c
+@@ -0,0 +1,171 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++/*
++ * Hardware monitoring driver for Infineon Multi-phase Digital VR Controllers
++ *
++ * Copyright (c) 2020 Mellanox Technologies. All rights reserved.
++ */
++
++#include <linux/err.h>
++#include <linux/i2c.h>
++#include <linux/init.h>
++#include <linux/kernel.h>
++#include <linux/module.h>
++#include "pmbus.h"
++
++#define XDPE122_PROT_VR12_5MV		0x01 /* VR12.0 mode, 5-mV DAC */
++#define XDPE122_PROT_VR12_5_10MV	0x02 /* VR12.5 mode, 10-mV DAC */
++#define XDPE122_PROT_IMVP9_10MV		0x03 /* IMVP9 mode, 10-mV DAC */
++#define XDPE122_AMD_625MV		0x10 /* AMD mode 6.25mV */
++#define XDPE122_PAGE_NUM		2
++
++static int xdpe122_read_word_data(struct i2c_client *client, int page, int reg)
++{
++	const struct pmbus_driver_info *info = pmbus_get_driver_info(client);
++	long val;
++	s16 exponent;
++	s32 mantissa;
++	int ret;
++
++	switch (reg) {
++	case PMBUS_VOUT_OV_FAULT_LIMIT:
++	case PMBUS_VOUT_UV_FAULT_LIMIT:
++		ret = pmbus_read_word_data(client, page, reg);
++		if (ret < 0)
++			return ret;
++
++		/* Convert register value to LINEAR11 data. */
++		exponent = ((s16)ret) >> 11;
++		mantissa = ((s16)((ret & GENMASK(10, 0)) << 5)) >> 5;
++		val = mantissa * 1000L;
++		if (exponent >= 0)
++			val <<= exponent;
++		else
++			val >>= -exponent;
++
++		/* Convert data to VID register. */
++		switch (info->vrm_version[page]) {
++		case vr13:
++			if (val >= 500)
++				return 1 + DIV_ROUND_CLOSEST(val - 500, 10);
++			return 0;
++		case vr12:
++			if (val >= 250)
++				return 1 + DIV_ROUND_CLOSEST(val - 250, 5);
++			return 0;
++		case imvp9:
++			if (val >= 200)
++				return 1 + DIV_ROUND_CLOSEST(val - 200, 10);
++			return 0;
++		case amd625mv:
++			if (val >= 200 && val <= 1550)
++				return DIV_ROUND_CLOSEST((1550 - val) * 100,
++							 625);
++			return 0;
++		default:
++			return -EINVAL;
++		}
++	default:
++		return -ENODATA;
++	}
++
++	return 0;
++}
++
++static int xdpe122_identify(struct i2c_client *client,
++			    struct pmbus_driver_info *info)
++{
++	u8 vout_params;
++	int i, ret;
++
++	for (i = 0; i < XDPE122_PAGE_NUM; i++) {
++		/* Read the register with VOUT scaling value.*/
++		ret = pmbus_read_byte_data(client, i, PMBUS_VOUT_MODE);
++		if (ret < 0)
++			return ret;
++
++		vout_params = ret & GENMASK(4, 0);
++
++		switch (vout_params) {
++		case XDPE122_PROT_VR12_5_10MV:
++			info->vrm_version[i] = vr13;
++			break;
++		case XDPE122_PROT_VR12_5MV:
++			info->vrm_version[i] = vr12;
++			break;
++		case XDPE122_PROT_IMVP9_10MV:
++			info->vrm_version[i] = imvp9;
++			break;
++		case XDPE122_AMD_625MV:
++			info->vrm_version[i] = amd625mv;
++			break;
++		default:
++			return -EINVAL;
++		}
++	}
++
++	return 0;
++}
++
++static struct pmbus_driver_info xdpe122_info = {
++	.pages = XDPE122_PAGE_NUM,
++	.format[PSC_VOLTAGE_IN] = linear,
++	.format[PSC_VOLTAGE_OUT] = vid,
++	.format[PSC_TEMPERATURE] = linear,
++	.format[PSC_CURRENT_IN] = linear,
++	.format[PSC_CURRENT_OUT] = linear,
++	.format[PSC_POWER] = linear,
++	.func[0] = PMBUS_HAVE_VIN | PMBUS_HAVE_VOUT | PMBUS_HAVE_STATUS_VOUT |
++		PMBUS_HAVE_IIN | PMBUS_HAVE_IOUT | PMBUS_HAVE_STATUS_IOUT |
++		PMBUS_HAVE_TEMP | PMBUS_HAVE_STATUS_TEMP |
++		PMBUS_HAVE_POUT | PMBUS_HAVE_PIN | PMBUS_HAVE_STATUS_INPUT,
++	.func[1] = PMBUS_HAVE_VIN | PMBUS_HAVE_VOUT | PMBUS_HAVE_STATUS_VOUT |
++		PMBUS_HAVE_IIN | PMBUS_HAVE_IOUT | PMBUS_HAVE_STATUS_IOUT |
++		PMBUS_HAVE_TEMP | PMBUS_HAVE_STATUS_TEMP |
++		PMBUS_HAVE_POUT | PMBUS_HAVE_PIN | PMBUS_HAVE_STATUS_INPUT,
++	.identify = xdpe122_identify,
++	.read_word_data = xdpe122_read_word_data,
++};
++
++static int xdpe122_probe(struct i2c_client *client,
++			 const struct i2c_device_id *id)
++{
++	struct pmbus_driver_info *info;
++
++	info = devm_kmemdup(&client->dev, &xdpe122_info, sizeof(*info),
++			    GFP_KERNEL);
++	if (!info)
++		return -ENOMEM;
++
++	return pmbus_do_probe(client, id, info);
++}
++
++static const struct i2c_device_id xdpe122_id[] = {
++	{"xdpe12254", 0},
++	{"xdpe12284", 0},
++	{}
++};
++
++MODULE_DEVICE_TABLE(i2c, xdpe122_id);
++
++static const struct of_device_id __maybe_unused xdpe122_of_match[] = {
++	{.compatible = "infineon,xdpe12254"},
++	{.compatible = "infineon,xdpe12284"},
++	{}
++};
++MODULE_DEVICE_TABLE(of, xdpe122_of_match);
++
++static struct i2c_driver xdpe122_driver = {
++	.driver = {
++		.name = "xdpe12284",
++		.of_match_table = of_match_ptr(xdpe122_of_match),
++	},
++	.probe = xdpe122_probe,
++	.remove = pmbus_do_remove,
++	.id_table = xdpe122_id,
++};
++
++module_i2c_driver(xdpe122_driver);
++
++MODULE_AUTHOR("Vadim Pasternak <vadimp@mellanox.com>");
++MODULE_DESCRIPTION("PMBus driver for Infineon XDPE122 family");
++MODULE_LICENSE("GPL");
+-- 
+2.11.0
+

--- a/patch/0061-i2c-busses-i2c-mlxcpld-Increase-transaction-pooli.patch
+++ b/patch/0061-i2c-busses-i2c-mlxcpld-Increase-transaction-pooli.patch
@@ -1,0 +1,31 @@
+From 10301ce5d3375b4a088710e3ce8ecc6f4acc6ed7 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Thu, 5 Mar 2020 13:09:06 +0200
+Subject: [hwmon v1] i2c: busses: i2c-mlxcpld: Increase transaction pooling
+ time
+
+i2c-mlxcpld polling time from 200 to 600 usec due to some
+problematic power supply units, which cannot work with
+such frequency.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/i2c/busses/i2c-mlxcpld.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/i2c/busses/i2c-mlxcpld.c b/drivers/i2c/busses/i2c-mlxcpld.c
+index 41b57027e348..6da4b58eee4f 100644
+--- a/drivers/i2c/busses/i2c-mlxcpld.c
++++ b/drivers/i2c/busses/i2c-mlxcpld.c
+@@ -51,7 +51,7 @@
+ #define MLXCPLD_I2C_MAX_ADDR_LEN	4
+ #define MLXCPLD_I2C_RETR_NUM		2
+ #define MLXCPLD_I2C_XFER_TO		500000 /* usec */
+-#define MLXCPLD_I2C_POLL_TIME		200   /* usec */
++#define MLXCPLD_I2C_POLL_TIME		400   /* usec */
+ 
+ /* LPC I2C registers */
+ #define MLXCPLD_LPCI2C_CPBLTY_REG	0x0
+-- 
+2.11.0
+

--- a/patch/0062-platform-mellanox-mlxreg-hotplug-Use-capability-r.patch
+++ b/patch/0062-platform-mellanox-mlxreg-hotplug-Use-capability-r.patch
@@ -1,0 +1,73 @@
+From af50fedeeaa767a0c7c3a9cf399fe23314adc609 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Thu, 12 Mar 2020 23:51:41 +0200
+Subject: [platform-next v1 1/2] platform/mellanox: mlxreg-hotplug: Use
+ capability register for attribute creation
+
+Create the 'sysfs' attributes according to configuration provided
+through the capability register, which purpose is to indicate the
+actual number of the components within the particular group.
+Such components could be, for example the FAN or power supply units.
+The motivation is to avoid adding a new code in the future in order to
+distinct between the systems types supported different number of the
+components like power supplies, FANs, ASICs, line cards.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/platform/mellanox/mlxreg-hotplug.c | 23 +++++++++++++++++++----
+ 1 file changed, 19 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlxreg-hotplug.c b/drivers/platform/mellanox/mlxreg-hotplug.c
+index 77be37a1fbcf..c21754821789 100644
+--- a/drivers/platform/mellanox/mlxreg-hotplug.c
++++ b/drivers/platform/mellanox/mlxreg-hotplug.c
+@@ -196,17 +196,29 @@ static int mlxreg_hotplug_attr_init(struct mlxreg_hotplug_priv_data *priv)
+ 	struct mlxreg_core_hotplug_platform_data *pdata;
+ 	struct mlxreg_core_item *item;
+ 	struct mlxreg_core_data *data;
+-	int num_attrs = 0, id = 0, i, j;
++	u32 regval;
++	int num_attrs = 0, id = 0, i, j, k, ret;
+ 
+ 	pdata = dev_get_platdata(&priv->pdev->dev);
+ 	item = pdata->items;
+ 
+ 	/* Go over all kinds of items - psu, pwr, fan. */
+ 	for (i = 0; i < pdata->counter; i++, item++) {
+-		num_attrs += item->count;
+ 		data = item->data;
+ 		/* Go over all units within the item. */
+-		for (j = 0; j < item->count; j++, data++, id++) {
++		for (j = 0, k = 0; j < item->count; j++, data++) {
++			if (data->capability) {
++				/*
++				 * Read capability register and skip non
++				 * relevant attributes.
++				 */
++				ret = regmap_read(priv->regmap,
++						  data->capability, &regval);
++				if (ret)
++					return ret;
++				if (!(regval & data->bit))
++					continue;
++			}
+ 			PRIV_ATTR(id) = &PRIV_DEV_ATTR(id).dev_attr.attr;
+ 			PRIV_ATTR(id)->name = devm_kasprintf(&priv->pdev->dev,
+ 							     GFP_KERNEL,
+@@ -224,9 +236,12 @@ static int mlxreg_hotplug_attr_init(struct mlxreg_hotplug_priv_data *priv)
+ 			PRIV_DEV_ATTR(id).dev_attr.show =
+ 						mlxreg_hotplug_attr_show;
+ 			PRIV_DEV_ATTR(id).nr = i;
+-			PRIV_DEV_ATTR(id).index = j;
++			PRIV_DEV_ATTR(id).index = k;
+ 			sysfs_attr_init(&PRIV_DEV_ATTR(id).dev_attr.attr);
++			id++;
++			k++;
+ 		}
++		num_attrs += k;
+ 	}
+ 
+ 	priv->group.attrs = devm_kcalloc(&priv->pdev->dev,
+-- 
+2.11.0
+

--- a/patch/0063-platform-mellanox-mlxreg-io-Add-support-for-compl.patch
+++ b/patch/0063-platform-mellanox-mlxreg-io-Add-support-for-compl.patch
@@ -1,0 +1,256 @@
+From e74853715ed50660960ee7891e1979c685ab2fde Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Fri, 13 Mar 2020 00:15:54 +0200
+Subject: [platform-next v1 2/2] platform/mellanox: mlxreg-io: Add support for
+ complex attributes
+
+Add support for attributes composed from few registers.
+Such attributes could occupy from 2 to 4 sequential registers.
+This is not the case for double word size register space, for word size
+register space complex attribute can occupy up to two register, for
+byte size - up to four. These attributes can carry, for example, CPLD
+or FPGA versioning, power consuming info, etcetera.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/platform/mellanox/mlxreg-io.c | 79 ++++++++++++++++++++++++++++++-----
+ drivers/platform/x86/mlx-platform.c   | 72 +++++++++++++++++++++++++++++++
+ 2 files changed, 141 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlxreg-io.c b/drivers/platform/mellanox/mlxreg-io.c
+index acfaf64ffde6..b8b8300928dd 100644
+--- a/drivers/platform/mellanox/mlxreg-io.c
++++ b/drivers/platform/mellanox/mlxreg-io.c
+@@ -19,6 +19,13 @@
+ /* Attribute parameters. */
+ #define MLXREG_IO_ATT_SIZE	10
+ #define MLXREG_IO_ATT_NUM	48
++#define MLXREG_IO_REGVAL_ARR	4
++#define MLXREG_IO_REG_8BIT	GENMASK(7, 0)
++#define MLXREG_IO_REG_16BIT	GENMASK(15, 0)
++#define MLXREG_IO_REG_24BIT	GENMASK(23, 0)
++#define MLXREG_IO_REG_32BIT	GENMASK(31, 0)
++#define MLXREG_IO_REG_BYTE	8
++#define MLXREG_IO_REG_WORD	16
+ 
+ /**
+  * struct mlxreg_io_priv_data - driver's private data:
+@@ -45,21 +52,23 @@ static int
+ mlxreg_io_get_reg(void *regmap, struct mlxreg_core_data *data, u32 in_val,
+ 		  bool rw_flag, u32 *regval)
+ {
+-	int ret;
++	u32 val;
++	int regnum, len, mask, i, ret;
+ 
+ 	ret = regmap_read(regmap, data->reg, regval);
+ 	if (ret)
+ 		goto access_error;
+-
+ 	/*
+-	 * There are three kinds of attributes: single bit, full register's
+-	 * bits and bit sequence. For the first kind field mask indicates which
+-	 * bits are not related and field bit is set zero. For the second kind
+-	 * field mask is set to zero and field bit is set with all bits one.
+-	 * No special handling for such kind of attributes - pass value as is.
+-	 * For the third kind, field mask indicates which bits are related and
+-	 * field bit is set to the first bit number (from 1 to 32) is the bit
+-	 * sequence.
++	 * There are four kinds of attributes: single bit, full register's
++	 * bits, bit sequence, bits in few registers For the first kind field
++	 * mask indicates which bits are not related and field bit is set zero.
++	 * For the second kind field mask is set to zero and field bit is set
++	 * with all bits one. No special handling for such kind of attributes -
++	 * pass value as is. For the third kind, field mask indicates which
++	 * bits are related and field bit is set to the first bit number (from
++	 * 1 to 32) is the bit sequence. For the fourth mask - the number of
++	 * registers which should be written for attribute are set according
++	 * to 'data->bit' field.
+ 	 */
+ 	if (!data->bit) {
+ 		/* Single bit. */
+@@ -83,6 +92,56 @@ mlxreg_io_get_reg(void *regmap, struct mlxreg_core_data *data, u32 in_val,
+ 			/* Clear relevant bits and set them to new value. */
+ 			*regval = (*regval & ~data->mask) | in_val;
+ 		}
++	} else {
++		/*
++		 * Some attributes could occupied few registers in case regmap
++		 * bit size is 8 or 16. Maximum register for such case is
++		 * respectively 0xff or 0xffff. Not relevant for the case, when
++		 * regmap bit size is 32 and maximum registers 0xffffffff.
++		 */
++		mask = regmap_get_max_register(regmap);
++		if (mask < 0)
++			goto access_error;
++
++		/*
++		 * Get register bit length and the number of registers from
++		 * wich this attribute is composed. Attribute can be located
++		 * in 1, 2, 3 or 4 registers.
++		 */
++		switch (mask) {
++		case MLXREG_IO_REG_8BIT:
++			if (data->bit > MLXREG_IO_REG_24BIT)
++				regnum = 4;
++			else if (data->bit > MLXREG_IO_REG_16BIT)
++				regnum = 3;
++			else if (data->bit > MLXREG_IO_REG_8BIT)
++				regnum = 2;
++			else
++				return ret;
++			len = MLXREG_IO_REG_BYTE;
++			break;
++		case MLXREG_IO_REG_16BIT:
++			if (data->bit > MLXREG_IO_REG_16BIT)
++				regnum = 2;
++			else
++				return ret;
++			len = MLXREG_IO_REG_WORD;
++			break;
++		case MLXREG_IO_REG_32BIT:
++			return ret;
++		default:
++			return -EINVAL;
++		}
++
++		/* Compose attribute from 'regnum' registers. */
++		for (i = 1; i < regnum; i++) {
++			ret = regmap_read(regmap, data->reg + i, &val);
++			if (ret)
++				goto access_error;
++
++			*regval |= rol32(val, len * i);
++		}
++		*regval = le32_to_cpu(*regval & mask);
+ 	}
+ 
+ access_error:
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index c27548fd386a..a916a1d7ce2d 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -26,6 +26,10 @@
+ #define MLXPLAT_CPLD_LPC_REG_CPLD2_VER_OFFSET	0x01
+ #define MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET	0x02
+ #define MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET	0x03
++#define MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET	0x04
++#define MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET	0x06
++#define MLXPLAT_CPLD_LPC_REG_CPLD3_PN_OFFSET	0x08
++#define MLXPLAT_CPLD_LPC_REG_CPLD4_PN_OFFSET	0x0a
+ #define MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET	0x1d
+ #define MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET	0x1e
+ #define MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET	0x1f
+@@ -72,6 +76,10 @@
+ #define MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET	0xd1
+ #define MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET	0xd2
+ #define MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET	0xd3
++#define MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET	0xde
++#define MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET	0xdf
++#define MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET	0xe0
++#define MLXPLAT_CPLD_LPC_REG_CPLD4_MVER_OFFSET	0xe1
+ #define MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET	0xe2
+ #define MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET	0xe3
+ #define MLXPLAT_CPLD_LPC_REG_TACHO1_OFFSET	0xe4
+@@ -1528,6 +1536,54 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mode = 0444,
+ 	},
+ 	{
++		.label = "cpld1_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld2_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld3_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD3_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld4_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD4_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld1_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld2_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld3_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld4_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD4_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
+ 		.label = "reset_long_pb",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(0),
+@@ -2006,6 +2062,10 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD3_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD4_PN_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET:
+@@ -2051,6 +2111,10 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD4_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_TACHO1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_TACHO2_OFFSET:
+@@ -2085,6 +2149,10 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD3_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD4_PN_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET:
+@@ -2122,6 +2190,10 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_WD2_TLEFT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD4_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_TACHO1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_TACHO2_OFFSET:
+-- 
+2.11.0
+

--- a/patch/0064-Add-config-for-sensor-xdpe122-and-modify-mlx_wdt-.patch
+++ b/patch/0064-Add-config-for-sensor-xdpe122-and-modify-mlx_wdt-.patch
@@ -1,0 +1,89 @@
+From 90ddafe594f825e72fcdf4294f60e73ba7a689f9 Mon Sep 17 00:00:00 2001
+From: Stephen Sun <stephens@mellanox.com>
+Date: Wed, 25 Mar 2020 15:07:34 +0000
+Subject: [PATCH] Add config for sensor xdpe122 and modify mlx_wdt to m
+Add the following options to kernel config file:
+CONFIG_SENSORS_XDPE122=m Modify the following
+options to kernel config file:
+CONFIG_MLX_WDT=y => CONFIG_MLX_WDT=m
+
+Signed-off-by: Stephen Sun <stephens@mellanox.com>
+---
+ debian/build/build_amd64_none_amd64/.config | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/debian/build/build_amd64_none_amd64/.config b/debian/build/build_amd64_none_amd64/.config
+index 6c4c6443..6ae593b6 100644
+--- a/debian/build/build_amd64_none_amd64/.config
++++ b/debian/build/build_amd64_none_amd64/.config
+@@ -707,7 +707,6 @@ CONFIG_ACPI_EXTLOG=y
+ # CONFIG_PMIC_OPREGION is not set
+ # CONFIG_ACPI_CONFIGFS is not set
+ CONFIG_SFI=y
+-CONFIG_SENSORS_MLXREG_FAN=m
+ 
+ #
+ # CPU Frequency scaling
+@@ -1453,6 +1452,7 @@ CONFIG_NET_ACT_POLICE=m
+ CONFIG_NET_ACT_GACT=m
+ CONFIG_GACT_PROB=y
+ CONFIG_NET_ACT_MIRRED=m
++CONFIG_NET_ACT_SAMPLE=m
+ CONFIG_NET_ACT_IPT=m
+ CONFIG_NET_ACT_NAT=m
+ CONFIG_NET_ACT_PEDIT=m
+@@ -1761,6 +1761,7 @@ CONFIG_NFC_PN533_USB=m
+ # CONFIG_NFC_PN533_I2C is not set
+ # CONFIG_NFC_MICROREAD_MEI is not set
+ # CONFIG_NFC_ST95HF is not set
++CONFIG_PSAMPLE=m
+ CONFIG_LWTUNNEL=y
+ CONFIG_DST_CACHE=y
+ CONFIG_NET_DEVLINK=m
+@@ -3925,6 +3926,7 @@ CONFIG_SENSORS_MAX6620=m
+ CONFIG_SENSORS_MAX6697=m
+ CONFIG_SENSORS_MAX31790=m
+ # CONFIG_SENSORS_MCP3021 is not set
++CONFIG_SENSORS_MLXREG_FAN=m
+ CONFIG_SENSORS_MENF21BMC_HWMON=m
+ CONFIG_SENSORS_ADCXX=m
+ CONFIG_SENSORS_LM63=m
+@@ -3966,8 +3968,9 @@ CONFIG_SENSORS_DNI_DPS460=m
+ CONFIG_SENSORS_TPS53679=m
+ CONFIG_SENSORS_UCD9000=m
+ CONFIG_SENSORS_UCD9200=m
+-CONFIG_SENSORS_DPS1900=m
++CONFIG_SENSORS_XDPE122=m
+ # CONFIG_SENSORS_ZL6100 is not set
++CONFIG_SENSORS_DPS1900=m
+ # CONFIG_SENSORS_SHT15 is not set
+ CONFIG_SENSORS_SHT21=m
+ # CONFIG_SENSORS_SHT3x is not set
+@@ -4057,6 +4060,7 @@ CONFIG_MENF21BMC_WATCHDOG=m
+ # CONFIG_WDAT_WDT is not set
+ # CONFIG_XILINX_WATCHDOG is not set
+ # CONFIG_ZIIRAVE_WATCHDOG is not set
++CONFIG_MLX_WDT=m
+ # CONFIG_CADENCE_WATCHDOG is not set
+ # CONFIG_DW_WATCHDOG is not set
+ # CONFIG_MAX63XX_WATCHDOG is not set
+@@ -4097,7 +4101,6 @@ CONFIG_SBC_EPX_C3_WATCHDOG=m
+ # CONFIG_NI903X_WDT is not set
+ # CONFIG_MEN_A21_WDT is not set
+ CONFIG_XEN_WDT=m
+-CONFIG_MLX_WDT=y
+ 
+ #
+ # PCI-based Watchdog Cards
+@@ -6139,7 +6142,7 @@ CONFIG_INTEL_MIC_X100_DMA=m
+ # CONFIG_QCOM_HIDMA is not set
+ CONFIG_DW_DMAC_CORE=m
+ CONFIG_DW_DMAC=m
+-# CONFIG_DW_DMAC_PCI is not set
++CONFIG_DW_DMAC_PCI=m
+ CONFIG_HSU_DMA=y
+ 
+ #
+-- 
+2.11.0
+

--- a/patch/0065-mlxsw-qsfp_sysfs-Remove-obsolete-code-for-QSFP-EEPRO.patch
+++ b/patch/0065-mlxsw-qsfp_sysfs-Remove-obsolete-code-for-QSFP-EEPRO.patch
@@ -1,0 +1,411 @@
+From 0deb2ef6a0ff3ba73dceb9361cd2c866c195dc7f Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Tue, 31 Mar 2020 22:36:17 +0300
+Subject: [mlxsw qsfp] mlxsw: qsfp_sysfs: Remove obsolete code for QSFP EEPROM
+ reading
+
+Remove QSFP EEPROM attribures from 'sysfs'.
+This code is obsoleted.
+
+Make de-init order symmetrical with init.
+    .
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core.c       |   4 +-
+ drivers/net/ethernet/mellanox/mlxsw/qsfp_sysfs.c | 299 +----------------------
+ 2 files changed, 13 insertions(+), 290 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core.c b/drivers/net/ethernet/mellanox/mlxsw/core.c
+index a127e0b01e4e..0583c7b328a5 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core.c
+@@ -1051,11 +1051,11 @@ void mlxsw_core_bus_device_unregister(struct mlxsw_core *mlxsw_core,
+ 			return;
+ 	}
+ 
+-	if (mlxsw_core->driver->fini)
+-		mlxsw_core->driver->fini(mlxsw_core);
+ 	mlxsw_qsfp_fini(mlxsw_core->qsfp);
+ 	mlxsw_thermal_fini(mlxsw_core->thermal);
+ 	mlxsw_hwmon_fini(mlxsw_core->hwmon);
++	if (mlxsw_core->driver->fini)
++		mlxsw_core->driver->fini(mlxsw_core);
+ 	if (!reload)
+ 		devlink_unregister(devlink);
+ 	mlxsw_emad_fini(mlxsw_core);
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/qsfp_sysfs.c b/drivers/net/ethernet/mellanox/mlxsw/qsfp_sysfs.c
+index 49563a703d75..931dbd58e4bd 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/qsfp_sysfs.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/qsfp_sysfs.c
+@@ -41,171 +41,18 @@
+ 
+ #include "core.h"
+ 
+-#define MLXSW_QSFP_I2C_ADDR		0x50
+-#define MLXSW_QSFP_PAGE_NUM		5
+-#define MLXSW_QSFP_PAGE_SIZE		128
+-#define MLXSW_QSFP_SUB_PAGE_NUM		3
+-#define MLXSW_QSFP_SUB_PAGE_SIZE	48
+-#define MLXSW_QSFP_LAST_SUB_PAGE_SIZE	32
+-#define MLXSW_QSFP_MAX_NUM		128
+-#define MLXSW_QSFP_MIN_REQ_LEN		4
+-#define MLXSW_QSFP_STATUS_VALID_TIME	(120 * HZ)
+-#define MLXSW_QSFP_MAX_CPLD_NUM		3
+-#define MLXSW_QSFP_MIN_CPLD_NUM		1
++#define MLXSW_QSFP_MAX_CPLD_NUM	3
++#define MLXSW_QSFP_MIN_CPLD_NUM	1
+ 
+-static const u8 mlxsw_qsfp_page_number[] = { 0xa0, 0x00, 0x01, 0x02, 0x03 };
+-static const u16 mlxsw_qsfp_page_shift[] = { 0x00, 0x80, 0x80, 0x80, 0x80 };
+-
+-/**
+- * Mellanox device Management Cable Info Access Register buffer for reading
+- * QSFP EEPROM info is limited by 48 bytes. In case full page is to be read
+- * (128 bytes), such request will be implemented by three transactions of size
+- * 48, 48, 32.
+- */
+-static const u16 mlxsw_qsfp_sub_page_size[] = {
+-	MLXSW_QSFP_SUB_PAGE_SIZE,
+-	MLXSW_QSFP_SUB_PAGE_SIZE,
+-	MLXSW_QSFP_LAST_SUB_PAGE_SIZE
+-};
+-
+-struct mlxsw_qsfp_module {
+-	unsigned long last_updated;
+-	u8 cache_status;
+-};
++static int mlxsw_qsfp_cpld_num = MLXSW_QSFP_MIN_CPLD_NUM;
+ 
+ struct mlxsw_qsfp {
+ 	struct mlxsw_core *core;
+ 	const struct mlxsw_bus_info *bus_info;
+-	struct attribute *attrs[MLXSW_QSFP_MAX_NUM + 1];
+-	struct device_attribute *dev_attrs;
+-	struct bin_attribute *eeprom;
+-	struct bin_attribute **eeprom_attr_list;
+-	struct mlxsw_qsfp_module modules[MLXSW_QSFP_MAX_NUM];
+-	u8 module_ind[MLXSW_QSFP_MAX_NUM];
+-	u8 module_count;
+ 	struct attribute *cpld_attrs[MLXSW_QSFP_MAX_CPLD_NUM + 1];
+ 	struct device_attribute *cpld_dev_attrs;
+ };
+ 
+-static int mlxsw_qsfp_cpld_num = MLXSW_QSFP_MIN_CPLD_NUM;
+-static int mlxsw_qsfp_num = MLXSW_QSFP_MAX_NUM / 2;
+-
+-static int
+-mlxsw_qsfp_query_module_eeprom(struct mlxsw_qsfp *mlxsw_qsfp, u8 index,
+-			       loff_t off, size_t count, int page, char *buf)
+-{
+-	char eeprom_tmp[MLXSW_QSFP_PAGE_SIZE];
+-	char mcia_pl[MLXSW_REG_MCIA_LEN];
+-	int status;
+-	int err;
+-
+-	mlxsw_reg_mcia_pack(mcia_pl, index, 0, page, off, count,
+-			    MLXSW_QSFP_I2C_ADDR);
+-
+-	err = mlxsw_reg_query(mlxsw_qsfp->core, MLXSW_REG(mcia), mcia_pl);
+-	if (err)
+-		return err;
+-
+-	status = mlxsw_reg_mcia_status_get(mcia_pl);
+-	if (status)
+-		return -EIO;
+-
+-	mlxsw_reg_mcia_eeprom_memcpy_from(mcia_pl, eeprom_tmp);
+-	memcpy(buf, eeprom_tmp, count);
+-
+-	return 0;
+-}
+-
+-static int
+-mlxsw_qsfp_get_module_eeprom(struct mlxsw_qsfp *mlxsw_qsfp, u8 index,
+-			     char *buf, loff_t off, size_t count)
+-{
+-	int page_ind, page, page_off, subpage, offset, size, res = 0;
+-	int err;
+-
+-	if (!count)
+-		return -EINVAL;
+-
+-	memset(buf, 0, count);
+-	size = count;
+-	while (res < count) {
+-		page_ind = off / MLXSW_QSFP_PAGE_SIZE;
+-		page_off = off % MLXSW_QSFP_PAGE_SIZE;
+-		page = mlxsw_qsfp_page_number[page_ind];
+-		offset = mlxsw_qsfp_page_shift[page_ind] + page_off;
+-		subpage = page_off / MLXSW_QSFP_SUB_PAGE_SIZE;
+-		size = min_t(u16, size, mlxsw_qsfp_sub_page_size[subpage]);
+-		err = mlxsw_qsfp_query_module_eeprom(mlxsw_qsfp, index, offset,
+-						     size, page, buf + res);
+-		if (err) {
+-			dev_err(mlxsw_qsfp->bus_info->dev, "Eeprom query failed\n");
+-			return err;
+-		}
+-		off += size;
+-		res += size;
+-		size = count - size;
+-	}
+-
+-	return res;
+-}
+-
+-static ssize_t mlxsw_qsfp_bin_read(struct file *filp, struct kobject *kobj,
+-				   struct bin_attribute *attr, char *buf,
+-				   loff_t off, size_t count)
+-{
+-	struct mlxsw_qsfp *mlxsw_qsfp = dev_get_platdata(container_of(kobj,
+-							 struct device, kobj));
+-	u8 *module_ind = attr->private;
+-	size_t size;
+-
+-	size = mlxsw_qsfp->eeprom[*module_ind].size;
+-
+-	if (off > size)
+-		return -ESPIPE;
+-	else if (off == size)
+-		return 0;
+-	else if ((off + count) > size)
+-		count = size - off;
+-
+-	return mlxsw_qsfp_get_module_eeprom(mlxsw_qsfp, *module_ind, buf, off,
+-					    count);
+-}
+-
+-static ssize_t
+-mlxsw_qsfp_status_show(struct device *dev, struct device_attribute *attr,
+-		       char *buf)
+-{
+-	struct mlxsw_qsfp *mlxsw_qsfp = dev_get_platdata(dev);
+-	char mcia_pl[MLXSW_REG_MCIA_LEN];
+-	int status;
+-	u32 i;
+-	int err;
+-
+-	for (i = 0; i < mlxsw_qsfp->module_count; i++) {
+-		if ((mlxsw_qsfp->dev_attrs + i) == attr)
+-			break;
+-	}
+-	if (i == mlxsw_qsfp->module_count)
+-		return -EINVAL;
+-
+-	if (time_before(jiffies, mlxsw_qsfp->modules[i].last_updated +
+-			MLXSW_QSFP_STATUS_VALID_TIME))
+-		return sprintf(buf, "%u\n",
+-			       mlxsw_qsfp->modules[i].cache_status);
+-
+-	mlxsw_reg_mcia_pack(mcia_pl, i, 0, 0, 0, MLXSW_QSFP_MIN_REQ_LEN,
+-			    MLXSW_QSFP_I2C_ADDR);
+-	err = mlxsw_reg_query(mlxsw_qsfp->core, MLXSW_REG(mcia), mcia_pl);
+-	if (err)
+-		return err;
+-
+-	status = mlxsw_reg_mcia_status_get(mcia_pl);
+-	mlxsw_qsfp->modules[i].cache_status = !status;
+-	mlxsw_qsfp->modules[i].last_updated = jiffies;
+-
+-	return sprintf(buf, "%u\n", !status);
+-}
+-
+ static ssize_t
+ mlxsw_qsfp_cpld_show(struct device *dev, struct device_attribute *attr,
+ 		     char *buf)
+@@ -239,13 +86,6 @@ static int mlxsw_qsfp_dmi_set_cpld_num(const struct dmi_system_id *dmi)
+ 	return 1;
+ };
+ 
+-static int mlxsw_qsfp_dmi_set_qsfp_num(const struct dmi_system_id *dmi)
+-{
+-	mlxsw_qsfp_num = MLXSW_QSFP_MAX_NUM;
+-
+-	return 1;
+-};
+-
+ static const struct dmi_system_id mlxsw_qsfp_dmi_table[] = {
+ 	{
+ 		.callback = mlxsw_qsfp_dmi_set_cpld_num,
+@@ -261,55 +101,18 @@ static const struct dmi_system_id mlxsw_qsfp_dmi_table[] = {
+ 			DMI_MATCH(DMI_PRODUCT_NAME, "MSN27"),
+ 		},
+ 	},
+-	{
+-		.callback = mlxsw_qsfp_dmi_set_qsfp_num,
+-		.matches = {
+-			DMI_MATCH(DMI_BOARD_VENDOR, "Mellanox Technologies"),
+-			DMI_MATCH(DMI_PRODUCT_NAME, "MSN37"),
+-		},
+-	},
+-	{
+-		.callback = mlxsw_qsfp_dmi_set_qsfp_num,
+-		.matches = {
+-			DMI_MATCH(DMI_BOARD_VENDOR, "Mellanox Technologies"),
+-			DMI_MATCH(DMI_PRODUCT_NAME, "MSN38"),
+-		},
+-	},
+ 	{ }
+ };
+ MODULE_DEVICE_TABLE(dmi, mlxsw_qsfp_dmi_table);
+ 
+-static int mlxsw_qsfp_set_module_num(struct mlxsw_qsfp *mlxsw_qsfp)
+-{
+-	char pmlp_pl[MLXSW_REG_PMLP_LEN];
+-	u8 width;
+-	int i, err;
+-
+-	for (i = 1; i <= mlxsw_qsfp_num; i++) {
+-		mlxsw_reg_pmlp_pack(pmlp_pl, i);
+-		err = mlxsw_reg_query(mlxsw_qsfp->core, MLXSW_REG(pmlp),
+-				      pmlp_pl);
+-		if (err)
+-			return err;
+-		width = mlxsw_reg_pmlp_width_get(pmlp_pl);
+-		if (!width)
+-			continue;
+-		mlxsw_qsfp->module_count++;
+-	}
+-
+-	return 0;
+-}
+ 
+ int mlxsw_qsfp_init(struct mlxsw_core *mlxsw_core,
+ 		    const struct mlxsw_bus_info *mlxsw_bus_info,
+ 		    struct mlxsw_qsfp **p_qsfp)
+ {
+-	struct device_attribute *dev_attr, *cpld_dev_attr;
+-	char mgpir_pl[MLXSW_REG_MGPIR_LEN];
++	struct device_attribute *cpld_dev_attr;
+ 	struct mlxsw_qsfp *mlxsw_qsfp;
+-	struct bin_attribute *eeprom;
+-	int i, count;
+-	int err;
++	int i, err;
+ 
+ 	if (!strcmp(mlxsw_bus_info->device_kind, "i2c"))
+ 		return 0;
+@@ -324,41 +127,6 @@ int mlxsw_qsfp_init(struct mlxsw_core *mlxsw_core,
+ 	mlxsw_qsfp->core = mlxsw_core;
+ 	mlxsw_qsfp->bus_info = mlxsw_bus_info;
+ 	mlxsw_bus_info->dev->platform_data = mlxsw_qsfp;
+-
+-	mlxsw_reg_mgpir_pack(mgpir_pl);
+-	err = mlxsw_reg_query(mlxsw_qsfp->core, MLXSW_REG(mgpir), mgpir_pl);
+-	if (err) {
+-		err = mlxsw_qsfp_set_module_num(mlxsw_qsfp);
+-		if (err)
+-			return err;
+-	} else {
+-		mlxsw_reg_mgpir_unpack(mgpir_pl, NULL, NULL, NULL,
+-			       &mlxsw_qsfp->module_count);
+-		if (!mlxsw_qsfp->module_count)
+-			return 0;
+-	}
+-
+-	count = mlxsw_qsfp->module_count + 1;
+-	mlxsw_qsfp->eeprom = devm_kzalloc(mlxsw_bus_info->dev,
+-					  mlxsw_qsfp->module_count *
+-					  sizeof(*mlxsw_qsfp->eeprom),
+-					  GFP_KERNEL);
+-	if (!mlxsw_qsfp->eeprom)
+-		return -ENOMEM;
+-
+-	mlxsw_qsfp->eeprom_attr_list = devm_kzalloc(mlxsw_bus_info->dev,
+-						    count *
+-						    sizeof(mlxsw_qsfp->eeprom),
+-						    GFP_KERNEL);
+-	if (!mlxsw_qsfp->eeprom_attr_list)
+-		return -ENOMEM;
+-
+-	mlxsw_qsfp->dev_attrs = devm_kzalloc(mlxsw_bus_info->dev, count *
+-					     sizeof(*mlxsw_qsfp->dev_attrs),
+-					     GFP_KERNEL);
+-	if (!mlxsw_qsfp->dev_attrs)
+-		return -ENOMEM;
+-
+ 	mlxsw_qsfp->cpld_dev_attrs = devm_kzalloc(mlxsw_bus_info->dev,
+ 					mlxsw_qsfp_cpld_num *
+ 					sizeof(*mlxsw_qsfp->cpld_dev_attrs),
+@@ -366,37 +134,6 @@ int mlxsw_qsfp_init(struct mlxsw_core *mlxsw_core,
+ 	if (!mlxsw_qsfp->cpld_dev_attrs)
+ 		return -ENOMEM;
+ 
+-	eeprom = mlxsw_qsfp->eeprom;
+-	dev_attr = mlxsw_qsfp->dev_attrs;
+-	for (i = 0; i < mlxsw_qsfp->module_count; i++, eeprom++, dev_attr++) {
+-		dev_attr->show = mlxsw_qsfp_status_show;
+-		dev_attr->attr.mode = 0444;
+-		dev_attr->attr.name = devm_kasprintf(mlxsw_bus_info->dev,
+-						     GFP_KERNEL,
+-						     "qsfp%d_status", i + 1);
+-		mlxsw_qsfp->attrs[i] = &dev_attr->attr;
+-		sysfs_attr_init(&dev_attr->attr);
+-		err = sysfs_create_file(&mlxsw_bus_info->dev->kobj,
+-					mlxsw_qsfp->attrs[i]);
+-		if (err)
+-			goto err_create_file;
+-
+-		sysfs_bin_attr_init(eeprom);
+-		eeprom->attr.name = devm_kasprintf(mlxsw_bus_info->dev,
+-						   GFP_KERNEL, "qsfp%d",
+-						   i + 1);
+-		eeprom->attr.mode = 0444;
+-		eeprom->read = mlxsw_qsfp_bin_read;
+-		eeprom->size = MLXSW_QSFP_PAGE_NUM * MLXSW_QSFP_PAGE_SIZE;
+-		mlxsw_qsfp->module_ind[i] = i;
+-		eeprom->private = &mlxsw_qsfp->module_ind[i];
+-		mlxsw_qsfp->eeprom_attr_list[i] = eeprom;
+-		err = sysfs_create_bin_file(&mlxsw_bus_info->dev->kobj,
+-					    eeprom);
+-		if (err)
+-			goto err_create_bin_file;
+-	}
+-
+ 	cpld_dev_attr = mlxsw_qsfp->cpld_dev_attrs;
+ 	for (i = 0; i < mlxsw_qsfp_cpld_num; i++, cpld_dev_attr++) {
+ 		cpld_dev_attr->show = mlxsw_qsfp_cpld_show;
+@@ -417,19 +154,9 @@ int mlxsw_qsfp_init(struct mlxsw_core *mlxsw_core,
+ 	return 0;
+ 
+ err_create_cpld_file:
+-	sysfs_remove_file(&mlxsw_bus_info->dev->kobj,
+-			  mlxsw_qsfp->cpld_attrs[i--]);
+-	i = mlxsw_qsfp->module_count;
+-err_create_bin_file:
+-	sysfs_remove_file(&mlxsw_bus_info->dev->kobj,
+-			  mlxsw_qsfp->attrs[i--]);
+-err_create_file:
+-	while (--i > 0) {
+-		sysfs_remove_bin_file(&mlxsw_bus_info->dev->kobj,
+-				      mlxsw_qsfp->eeprom_attr_list[i]);
++	while (--i > 0)
+ 		sysfs_remove_file(&mlxsw_bus_info->dev->kobj,
+-				  mlxsw_qsfp->attrs[i]);
+-	}
++				  mlxsw_qsfp->cpld_attrs[i]);
+ 
+ 	return err;
+ }
+@@ -438,15 +165,11 @@ void mlxsw_qsfp_fini(struct mlxsw_qsfp *mlxsw_qsfp)
+ {
+ 	int i;
+ 
+-	if (!strcmp(mlxsw_qsfp->bus_info->device_kind, "i2c"))
+-		return;
+-
+-	for (i = mlxsw_qsfp->module_count - 1; i >= 0; i--) {
+-		sysfs_remove_bin_file(&mlxsw_qsfp->bus_info->dev->kobj,
+-				      mlxsw_qsfp->eeprom_attr_list[i]);
++	for (i = 0; i < mlxsw_qsfp_cpld_num; i++)
+ 		sysfs_remove_file(&mlxsw_qsfp->bus_info->dev->kobj,
+-				  mlxsw_qsfp->attrs[i]);
+-	}
++				  mlxsw_qsfp->cpld_attrs[i]);
++	devm_kfree(mlxsw_qsfp->bus_info->dev, mlxsw_qsfp->cpld_dev_attrs);
++	devm_kfree(mlxsw_qsfp->bus_info->dev, mlxsw_qsfp);
+ }
+ 
+ MODULE_LICENSE("Dual BSD/GPL");
+-- 
+2.11.0
+

--- a/patch/0066-platform-mellanox-mlxreg-hotplug-Add-environmental-d.patch
+++ b/patch/0066-platform-mellanox-mlxreg-hotplug-Add-environmental-d.patch
@@ -1,0 +1,76 @@
+From 70806251c220166064c7b9fdb1543f814dbbb3ed Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Thu, 9 Apr 2020 12:06:20 +0300
+Subject: [backport] platform/mellanox: mlxreg-hotplug: Add environmental data
+ to uevent
+
+Send "udev" event with environmental data in order to allow handling
+"ENV{}" variables in "udev" rules.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/platform/mellanox/mlxreg-hotplug.c | 28 ++++++++++++++++++++++++++--
+ 1 file changed, 26 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlxreg-hotplug.c b/drivers/platform/mellanox/mlxreg-hotplug.c
+index 832fcf282d45..3e99ad9fe553 100644
+--- a/drivers/platform/mellanox/mlxreg-hotplug.c
++++ b/drivers/platform/mellanox/mlxreg-hotplug.c
+@@ -32,6 +32,7 @@
+  */
+ 
+ #include <linux/bitops.h>
++#include <linux/ctype.h>
+ #include <linux/device.h>
+ #include <linux/hwmon.h>
+ #include <linux/hwmon-sysfs.h>
+@@ -97,13 +98,36 @@ struct mlxreg_hotplug_priv_data {
+ 	u8 not_asserted;
+ };
+ 
++/* Environment variables array for udev. */
++static char *mlxreg_hotplug_udev_envp[] = { NULL, NULL };
++
++static int
++mlxreg_hotplug_udev_event_send(struct kobject *kobj,
++			       struct mlxreg_core_data *data, bool action)
++{
++	char event_str[MLXREG_CORE_LABEL_MAX_SIZE + 2];
++	char label[MLXREG_CORE_LABEL_MAX_SIZE] = { 0 };
++	int i;
++
++	mlxreg_hotplug_udev_envp[0] = event_str;
++	for (i = 0; data->label[i]; i++)
++		label[i] = toupper(data->label[i]);
++
++	if (action)
++		snprintf(event_str, MLXREG_CORE_LABEL_MAX_SIZE, "%s=1", label);
++	else
++		snprintf(event_str, MLXREG_CORE_LABEL_MAX_SIZE, "%s=0", label);
++
++	return kobject_uevent_env(kobj, KOBJ_CHANGE, mlxreg_hotplug_udev_envp);
++}
++
+ static int mlxreg_hotplug_device_create(struct mlxreg_hotplug_priv_data *priv,
+ 					struct mlxreg_core_data *data)
+ {
+ 	struct mlxreg_core_hotplug_platform_data *pdata;
+ 
+ 	/* Notify user by sending hwmon uevent. */
+-	kobject_uevent(&priv->hwmon->kobj, KOBJ_CHANGE);
++	mlxreg_hotplug_udev_event_send(&priv->hwmon->kobj, data, true);
+ 
+ 	/*
+ 	 * Return if adapter number is negative. It could be in case hotplug
+@@ -141,7 +165,7 @@ mlxreg_hotplug_device_destroy(struct mlxreg_hotplug_priv_data *priv,
+ 			      struct mlxreg_core_data *data)
+ {
+ 	/* Notify user by sending hwmon uevent. */
+-	kobject_uevent(&priv->hwmon->kobj, KOBJ_CHANGE);
++	mlxreg_hotplug_udev_event_send(&priv->hwmon->kobj, data, false);
+ 
+ 	if (data->hpdev.client) {
+ 		i2c_unregister_device(data->hpdev.client);
+-- 
+2.11.0
+

--- a/patch/Support-for-fullcone-nat.patch
+++ b/patch/Support-for-fullcone-nat.patch
@@ -1,0 +1,693 @@
+From 67cc2bd46c7ad1431ddd1819cdfad6ecc08a7593 Mon Sep 17 00:00:00 2001
+From: Kiran Kella <kiran.kella@broadcom.com>
+Date: Fri, 6 Sep 2019 20:54:19 -0700
+Subject: [PATCH] Support for fullcone nat
+
+---
+ include/net/netfilter/nf_conntrack.h     |   4 +
+ include/net/netfilter/nf_nat.h           |   6 +
+ include/net/netfilter/nf_nat_l4proto.h   |  12 +-
+ include/uapi/linux/netfilter/nf_nat.h    |   1 +
+ net/ipv4/netfilter/nf_nat_proto_gre.c    |   8 +-
+ net/ipv4/netfilter/nf_nat_proto_icmp.c   |   6 +-
+ net/ipv6/netfilter/nf_nat_proto_icmpv6.c |   5 +-
+ net/netfilter/nf_nat_core.c              | 175 ++++++++++++++++++++---
+ net/netfilter/nf_nat_proto_common.c      |  23 ++-
+ net/netfilter/nf_nat_proto_dccp.c        |   6 +-
+ net/netfilter/nf_nat_proto_sctp.c        |   6 +-
+ net/netfilter/nf_nat_proto_tcp.c         |   6 +-
+ net/netfilter/nf_nat_proto_udp.c         |   6 +-
+ net/netfilter/nf_nat_proto_udplite.c     |   6 +-
+ net/netfilter/nf_nat_proto_unknown.c     |   4 +-
+ 15 files changed, 220 insertions(+), 54 deletions(-)
+
+diff --git a/include/net/netfilter/nf_conntrack.h b/include/net/netfilter/nf_conntrack.h
+index 9ae819e..91796e9 100644
+--- a/include/net/netfilter/nf_conntrack.h
++++ b/include/net/netfilter/nf_conntrack.h
+@@ -102,6 +102,10 @@ struct nf_conn {
+ #if IS_ENABLED(CONFIG_NF_NAT)
+ 	struct hlist_node	nat_bysource;
+ #endif
++
++        /* To optionally ensure 3-tuple uniqueness on the translated source */
++        struct hlist_node       nat_by_manip_src;
++
+ 	/* all members below initialized via memset */
+ 	u8 __nfct_init_offset[0];
+ 
+diff --git a/include/net/netfilter/nf_nat.h b/include/net/netfilter/nf_nat.h
+index 02515f7..8d4d180 100644
+--- a/include/net/netfilter/nf_nat.h
++++ b/include/net/netfilter/nf_nat.h
+@@ -50,6 +50,12 @@ struct nf_conn_nat *nf_ct_nat_ext_add(struct nf_conn *ct);
+ int nf_nat_used_tuple(const struct nf_conntrack_tuple *tuple,
+ 		      const struct nf_conn *ignored_conntrack);
+ 
++/* Is this 3-tuple already taken? (not by us)*/
++int
++nf_nat_used_3_tuple(const struct nf_conntrack_tuple *tuple,
++		    const struct nf_conn *ignored_conntrack,
++		    enum nf_nat_manip_type maniptype);
++
+ static inline struct nf_conn_nat *nfct_nat(const struct nf_conn *ct)
+ {
+ #if defined(CONFIG_NF_NAT) || defined(CONFIG_NF_NAT_MODULE)
+diff --git a/include/net/netfilter/nf_nat_l4proto.h b/include/net/netfilter/nf_nat_l4proto.h
+index 12f4cc8..cfcd10c 100644
+--- a/include/net/netfilter/nf_nat_l4proto.h
++++ b/include/net/netfilter/nf_nat_l4proto.h
+@@ -31,7 +31,7 @@ struct nf_nat_l4proto {
+ 	 * possible.  Per-protocol part of tuple is initialized to the
+ 	 * incoming packet.
+ 	 */
+-	void (*unique_tuple)(const struct nf_nat_l3proto *l3proto,
++	int (*unique_tuple)(const struct nf_nat_l3proto *l3proto,
+ 			     struct nf_conntrack_tuple *tuple,
+ 			     const struct nf_nat_range *range,
+ 			     enum nf_nat_manip_type maniptype,
+@@ -60,11 +60,11 @@ bool nf_nat_l4proto_in_range(const struct nf_conntrack_tuple *tuple,
+ 			     const union nf_conntrack_man_proto *min,
+ 			     const union nf_conntrack_man_proto *max);
+ 
+-void nf_nat_l4proto_unique_tuple(const struct nf_nat_l3proto *l3proto,
+-				 struct nf_conntrack_tuple *tuple,
+-				 const struct nf_nat_range *range,
+-				 enum nf_nat_manip_type maniptype,
+-				 const struct nf_conn *ct, u16 *rover);
++int nf_nat_l4proto_unique_tuple(const struct nf_nat_l3proto *l3proto,
++				struct nf_conntrack_tuple *tuple,
++				const struct nf_nat_range *range,
++				enum nf_nat_manip_type maniptype,
++				const struct nf_conn *ct, u16 *rover);
+ 
+ int nf_nat_l4proto_nlattr_to_range(struct nlattr *tb[],
+ 				   struct nf_nat_range *range);
+diff --git a/include/uapi/linux/netfilter/nf_nat.h b/include/uapi/linux/netfilter/nf_nat.h
+index 0880781..5e43ce8 100644
+--- a/include/uapi/linux/netfilter/nf_nat.h
++++ b/include/uapi/linux/netfilter/nf_nat.h
+@@ -9,6 +9,7 @@
+ #define NF_NAT_RANGE_PROTO_RANDOM		(1 << 2)
+ #define NF_NAT_RANGE_PERSISTENT			(1 << 3)
+ #define NF_NAT_RANGE_PROTO_RANDOM_FULLY		(1 << 4)
++#define NF_NAT_RANGE_FULLCONE		        (1 << 5)
+ 
+ #define NF_NAT_RANGE_PROTO_RANDOM_ALL		\
+ 	(NF_NAT_RANGE_PROTO_RANDOM | NF_NAT_RANGE_PROTO_RANDOM_FULLY)
+diff --git a/net/ipv4/netfilter/nf_nat_proto_gre.c b/net/ipv4/netfilter/nf_nat_proto_gre.c
+index edf0500..8518466 100644
+--- a/net/ipv4/netfilter/nf_nat_proto_gre.c
++++ b/net/ipv4/netfilter/nf_nat_proto_gre.c
+@@ -38,7 +38,7 @@ MODULE_AUTHOR("Harald Welte <laforge@gnumonks.org>");
+ MODULE_DESCRIPTION("Netfilter NAT protocol helper module for GRE");
+ 
+ /* generate unique tuple ... */
+-static void
++static int
+ gre_unique_tuple(const struct nf_nat_l3proto *l3proto,
+ 		 struct nf_conntrack_tuple *tuple,
+ 		 const struct nf_nat_range *range,
+@@ -52,7 +52,7 @@ gre_unique_tuple(const struct nf_nat_l3proto *l3proto,
+ 	/* If there is no master conntrack we are not PPTP,
+ 	   do not change tuples */
+ 	if (!ct->master)
+-		return;
++		return 0;
+ 
+ 	if (maniptype == NF_NAT_MANIP_SRC)
+ 		keyptr = &tuple->src.u.gre.key;
+@@ -73,11 +73,11 @@ gre_unique_tuple(const struct nf_nat_l3proto *l3proto,
+ 	for (i = 0; ; ++key) {
+ 		*keyptr = htons(min + key % range_size);
+ 		if (++i == range_size || !nf_nat_used_tuple(tuple, ct))
+-			return;
++			return 1;
+ 	}
+ 
+ 	pr_debug("%p: no NAT mapping\n", ct);
+-	return;
++	return 0;
+ }
+ 
+ /* manipulate a GRE packet according to maniptype */
+diff --git a/net/ipv4/netfilter/nf_nat_proto_icmp.c b/net/ipv4/netfilter/nf_nat_proto_icmp.c
+index 7b98baa..d45face 100644
+--- a/net/ipv4/netfilter/nf_nat_proto_icmp.c
++++ b/net/ipv4/netfilter/nf_nat_proto_icmp.c
+@@ -27,7 +27,7 @@ icmp_in_range(const struct nf_conntrack_tuple *tuple,
+ 	       ntohs(tuple->src.u.icmp.id) <= ntohs(max->icmp.id);
+ }
+ 
+-static void
++static int
+ icmp_unique_tuple(const struct nf_nat_l3proto *l3proto,
+ 		  struct nf_conntrack_tuple *tuple,
+ 		  const struct nf_nat_range *range,
+@@ -48,9 +48,9 @@ icmp_unique_tuple(const struct nf_nat_l3proto *l3proto,
+ 		tuple->src.u.icmp.id = htons(ntohs(range->min_proto.icmp.id) +
+ 					     (id % range_size));
+ 		if (++i == range_size || !nf_nat_used_tuple(tuple, ct))
+-			return;
++			return 1;
+ 	}
+-	return;
++	return 0;
+ }
+ 
+ static bool
+diff --git a/net/ipv6/netfilter/nf_nat_proto_icmpv6.c b/net/ipv6/netfilter/nf_nat_proto_icmpv6.c
+index 57593b0..271674a 100644
+--- a/net/ipv6/netfilter/nf_nat_proto_icmpv6.c
++++ b/net/ipv6/netfilter/nf_nat_proto_icmpv6.c
+@@ -29,7 +29,7 @@ icmpv6_in_range(const struct nf_conntrack_tuple *tuple,
+ 	       ntohs(tuple->src.u.icmp.id) <= ntohs(max->icmp.id);
+ }
+ 
+-static void
++static int
+ icmpv6_unique_tuple(const struct nf_nat_l3proto *l3proto,
+ 		    struct nf_conntrack_tuple *tuple,
+ 		    const struct nf_nat_range *range,
+@@ -50,8 +50,9 @@ icmpv6_unique_tuple(const struct nf_nat_l3proto *l3proto,
+ 		tuple->src.u.icmp.id = htons(ntohs(range->min_proto.icmp.id) +
+ 					     (id % range_size));
+ 		if (++i == range_size || !nf_nat_used_tuple(tuple, ct))
+-			return;
++			return 1;
+ 	}
++	return 0;
+ }
+ 
+ static bool
+diff --git a/net/netfilter/nf_nat_core.c b/net/netfilter/nf_nat_core.c
+index 51b0d83..d6efc9b 100644
+--- a/net/netfilter/nf_nat_core.c
++++ b/net/netfilter/nf_nat_core.c
+@@ -39,6 +39,7 @@ static const struct nf_nat_l4proto __rcu **nf_nat_l4protos[NFPROTO_NUMPROTO]
+ 						__read_mostly;
+ 
+ static struct hlist_head *nf_nat_bysource __read_mostly;
++static struct hlist_head *nf_nat_by_manip_src __read_mostly;
+ static unsigned int nf_nat_htable_size __read_mostly;
+ static unsigned int nf_nat_hash_rnd __read_mostly;
+ 
+@@ -134,6 +135,31 @@ hash_by_src(const struct net *n, const struct nf_conntrack_tuple *tuple)
+ 	return reciprocal_scale(hash, nf_nat_htable_size);
+ }
+ 
++static inline unsigned int
++hash_by_dst(const struct net *n, const struct nf_conntrack_tuple *tuple)
++{
++	unsigned int hash;
++
++	get_random_once(&nf_nat_hash_rnd, sizeof(nf_nat_hash_rnd));
++
++	hash = jhash2((u32 *)&tuple->dst, sizeof(tuple->dst) / sizeof(u32),
++		      tuple->dst.protonum ^ nf_nat_hash_rnd ^ net_hash_mix(n));
++
++	return reciprocal_scale(hash, nf_nat_htable_size);
++}
++
++static inline int
++same_reply_dst(const struct nf_conn *ct,
++	       const struct nf_conntrack_tuple *tuple)
++{
++	const struct nf_conntrack_tuple *t;
++
++	t = &ct->tuplehash[IP_CT_DIR_REPLY].tuple;
++	return (t->dst.protonum == tuple->dst.protonum &&
++		nf_inet_addr_cmp(&t->dst.u3, &tuple->dst.u3) &&
++		t->dst.u.all == tuple->dst.u.all);
++}
++
+ /* Is this tuple already taken? (not by us) */
+ int
+ nf_nat_used_tuple(const struct nf_conntrack_tuple *tuple,
+@@ -150,7 +176,41 @@ nf_nat_used_tuple(const struct nf_conntrack_tuple *tuple,
+ 	nf_ct_invert_tuplepr(&reply, tuple);
+ 	return nf_conntrack_tuple_taken(&reply, ignored_conntrack);
+ }
++
++/* Is this 3-tuple already taken? (not by us) */
++int
++nf_nat_used_3_tuple(const struct nf_conntrack_tuple *tuple,
++		    const struct nf_conn *ignored_conntrack,
++		    enum nf_nat_manip_type maniptype)
++{
++	const struct nf_conn *ct;
++	const struct nf_conntrack_zone *zone;
++	unsigned int h;
++	struct net *net = nf_ct_net(ignored_conntrack);
++
++	/* 3-tuple uniqueness is required for translated source only */
++	if (maniptype != NF_NAT_MANIP_SRC) {
++		return 0;
++	}
++	zone = nf_ct_zone(ignored_conntrack);
++
++	/* The tuple passed here is the inverted reply (with translated source) */
++	h = hash_by_src(net, tuple);
++	hlist_for_each_entry_rcu(ct, &nf_nat_by_manip_src[h], nat_by_manip_src) {
++		struct nf_conntrack_tuple reply;
++		nf_ct_invert_tuplepr(&reply, tuple);
++		/* Compare against the destination in the reply */
++		if (same_reply_dst(ct, &reply) &&
++	    		net_eq(net, nf_ct_net(ct)) &&
++	    		nf_ct_zone_equal(ct, zone, IP_CT_DIR_ORIGINAL)) {
++				return 1;
++		}
++	}
++	return 0;
++}
++
+ EXPORT_SYMBOL(nf_nat_used_tuple);
++EXPORT_SYMBOL(nf_nat_used_3_tuple);
+ 
+ /* If we source map this tuple so reply looks like reply_tuple, will
+  * that meet the constraints of range.
+@@ -216,6 +276,36 @@ find_appropriate_src(struct net *net,
+ 	return 0;
+ }
+ 
++/* Only called for DST manip */
++static int
++find_appropriate_dst(struct net *net,
++		     const struct nf_conntrack_zone *zone,
++		     const struct nf_nat_l3proto *l3proto,
++		     const struct nf_nat_l4proto *l4proto,
++		     const struct nf_conntrack_tuple *tuple,
++		     struct nf_conntrack_tuple *result)
++{
++	struct nf_conntrack_tuple reply;
++	unsigned int h;
++	const struct nf_conn *ct;
++
++	nf_ct_invert_tuplepr(&reply, tuple);
++	h = hash_by_src(net, &reply);
++
++	hlist_for_each_entry_rcu(ct, &nf_nat_by_manip_src[h], nat_by_manip_src) {
++		if (same_reply_dst(ct, tuple) &&
++		    net_eq(net, nf_ct_net(ct)) &&
++		    nf_ct_zone_equal(ct, zone, IP_CT_DIR_REPLY)) {
++			/* Copy destination part from original tuple. */
++			nf_ct_invert_tuplepr(result,
++				       &ct->tuplehash[IP_CT_DIR_ORIGINAL].tuple);
++			result->src = tuple->src;
++			return 1;
++		}
++	}
++	return 0;
++}
++
+ /* For [FUTURE] fragmentation handling, we want the least-used
+  * src-ip/dst-ip/proto triple.  Fairness doesn't come into it.  Thus
+  * if the range specifies 1.2.3.4 ports 10000-10005 and 1.2.3.5 ports
+@@ -293,10 +383,15 @@ find_best_ips_proto(const struct nf_conntrack_zone *zone,
+ /* Manipulate the tuple into the range given. For NF_INET_POST_ROUTING,
+  * we change the source to map into the range. For NF_INET_PRE_ROUTING
+  * and NF_INET_LOCAL_OUT, we change the destination to map into the
+- * range. It might not be possible to get a unique tuple, but we try.
++ * range. It might not be possible to get a unique 5-tuple, but we try.
+  * At worst (or if we race), we will end up with a final duplicate in
+- * __ip_conntrack_confirm and drop the packet. */
+-static void
++ * __nf_conntrack_confirm and drop the packet.
++ * If the range is of type fullcone, if we end up with a 3-tuple
++ * duplicate, we do not wait till the packet reaches the
++ * nf_conntrack_confirm to drop the packet. Instead return the packet
++ * to be dropped at this stage.
++ * */
++static int
+ get_unique_tuple(struct nf_conntrack_tuple *tuple,
+ 		 const struct nf_conntrack_tuple *orig_tuple,
+ 		 const struct nf_nat_range *range,
+@@ -306,8 +401,11 @@ get_unique_tuple(struct nf_conntrack_tuple *tuple,
+ 	const struct nf_conntrack_zone *zone;
+ 	const struct nf_nat_l3proto *l3proto;
+ 	const struct nf_nat_l4proto *l4proto;
++	struct nf_nat_range nat_range;
+ 	struct net *net = nf_ct_net(ct);
+ 
++	memcpy(&nat_range, range, sizeof(struct nf_nat_range));
++
+ 	zone = nf_ct_zone(ct);
+ 
+ 	rcu_read_lock();
+@@ -324,47 +422,75 @@ get_unique_tuple(struct nf_conntrack_tuple *tuple,
+ 	 * manips not an issue.
+ 	 */
+ 	if (maniptype == NF_NAT_MANIP_SRC &&
+-	    !(range->flags & NF_NAT_RANGE_PROTO_RANDOM_ALL)) {
++	    !(nat_range.flags & NF_NAT_RANGE_PROTO_RANDOM_ALL)) {
+ 		/* try the original tuple first */
+-		if (in_range(l3proto, l4proto, orig_tuple, range)) {
++		if (in_range(l3proto, l4proto, orig_tuple, &nat_range)) {
+ 			if (!nf_nat_used_tuple(orig_tuple, ct)) {
+ 				*tuple = *orig_tuple;
+ 				goto out;
+ 			}
+ 		} else if (find_appropriate_src(net, zone, l3proto, l4proto,
+-						orig_tuple, tuple, range)) {
++						orig_tuple, tuple, &nat_range)) {
+ 			pr_debug("get_unique_tuple: Found current src map\n");
+ 			if (!nf_nat_used_tuple(tuple, ct))
+ 				goto out;
+ 		}
+ 	}
++	if (maniptype == NF_NAT_MANIP_DST) {
++		if (nat_range.flags & NF_NAT_RANGE_FULLCONE) {
++			/* Destination IP range does not apply when fullcone flag is set. */
++			nat_range.min_addr.ip = nat_range.max_addr.ip = orig_tuple->dst.u3.ip;
++			nat_range.min_proto.all = nat_range.max_proto.all = 0;
++
++			/* If this dstip/proto/dst-proto-part is mapped currently
++			 * as a translated source for a given tuple, use that
++			 */
++			if (find_appropriate_dst(net, zone, l3proto, l4proto,
++					 	orig_tuple, tuple)) {
++				if (!nf_nat_used_tuple(tuple, ct)) {
++					goto out;
++				}
++			} else {
++				/* If not mapped, proceed with the original tuple */
++				*tuple = *orig_tuple;
++				goto out;
++			} 
++		}
++	}
+ 
+ 	/* 2) Select the least-used IP/proto combination in the given range */
+ 	*tuple = *orig_tuple;
+-	find_best_ips_proto(zone, tuple, range, ct, maniptype);
++	find_best_ips_proto(zone, tuple, &nat_range, ct, maniptype);
+ 
+ 	/* 3) The per-protocol part of the manip is made to map into
+ 	 * the range to make a unique tuple.
+ 	 */
+ 
+ 	/* Only bother mapping if it's not already in range and unique */
+-	if (!(range->flags & NF_NAT_RANGE_PROTO_RANDOM_ALL)) {
+-		if (range->flags & NF_NAT_RANGE_PROTO_SPECIFIED) {
++	if (!(nat_range.flags & NF_NAT_RANGE_PROTO_RANDOM_ALL)) {
++		if (nat_range.flags & NF_NAT_RANGE_PROTO_SPECIFIED) {
+ 			if (l4proto->in_range(tuple, maniptype,
+-					      &range->min_proto,
+-					      &range->max_proto) &&
+-			    (range->min_proto.all == range->max_proto.all ||
+-			     !nf_nat_used_tuple(tuple, ct)))
+-				goto out;
++					      &(nat_range.min_proto),
++					      &(nat_range.max_proto))) {
++				if (nat_range.flags & NF_NAT_RANGE_FULLCONE) {
++					if (!nf_nat_used_3_tuple(tuple, ct, maniptype))
++						goto out;
++				} else {
++					if ((nat_range.min_proto.all == nat_range.max_proto.all) ||
++				            !nf_nat_used_tuple(tuple, ct))
++						goto out;
++				}
++			}
+ 		} else if (!nf_nat_used_tuple(tuple, ct)) {
+ 			goto out;
+ 		}
+ 	}
+ 
+ 	/* Last change: get protocol to try to obtain unique tuple. */
+-	l4proto->unique_tuple(l3proto, tuple, range, maniptype, ct);
++	return l4proto->unique_tuple(l3proto, tuple, &nat_range, maniptype, ct);
+ out:
+ 	rcu_read_unlock();
++	return 1;
+ }
+ 
+ struct nf_conn_nat *nf_ct_nat_ext_add(struct nf_conn *ct)
+@@ -406,7 +532,9 @@ nf_nat_setup_info(struct nf_conn *ct,
+ 	nf_ct_invert_tuplepr(&curr_tuple,
+ 			     &ct->tuplehash[IP_CT_DIR_REPLY].tuple);
+ 
+-	get_unique_tuple(&new_tuple, &curr_tuple, range, ct, maniptype);
++	if (! get_unique_tuple(&new_tuple, &curr_tuple, range, ct, maniptype)) {
++		return NF_DROP;
++	}
+ 
+ 	if (!nf_ct_tuple_equal(&new_tuple, &curr_tuple)) {
+ 		struct nf_conntrack_tuple reply;
+@@ -428,10 +556,16 @@ nf_nat_setup_info(struct nf_conn *ct,
+ 
+ 	if (maniptype == NF_NAT_MANIP_SRC) {
+ 		unsigned int srchash;
++		unsigned int manip_src_hash;
+ 
++		manip_src_hash = hash_by_src(net, &new_tuple);
+ 		srchash = hash_by_src(net,
+ 				      &ct->tuplehash[IP_CT_DIR_ORIGINAL].tuple);
++
+ 		spin_lock_bh(&nf_nat_lock);
++		hlist_add_head_rcu(&ct->nat_by_manip_src,
++				   &nf_nat_by_manip_src[manip_src_hash]);
++
+ 		/* nf_conntrack_alter_reply might re-allocate extension aera */
+ 		nat = nfct_nat(ct);
+ 		hlist_add_head_rcu(&ct->nat_bysource,
+@@ -546,6 +680,7 @@ static int nf_nat_proto_clean(struct nf_conn *ct, void *data)
+ 	 */
+ 	spin_lock_bh(&nf_nat_lock);
+ 	hlist_del_rcu(&ct->nat_bysource);
++	hlist_del_rcu(&ct->nat_by_manip_src);
+ 	ct->status &= ~IPS_NAT_DONE_MASK;
+ 	spin_unlock_bh(&nf_nat_lock);
+ 
+@@ -675,6 +810,7 @@ static void nf_nat_cleanup_conntrack(struct nf_conn *ct)
+ 	if (ct->status & IPS_SRC_NAT_DONE) {
+ 		spin_lock_bh(&nf_nat_lock);
+ 		hlist_del_rcu(&ct->nat_bysource);
++		hlist_del_rcu(&ct->nat_by_manip_src);
+ 		spin_unlock_bh(&nf_nat_lock);
+ 	}
+ }
+@@ -818,9 +954,14 @@ static int __init nf_nat_init(void)
+ 	if (!nf_nat_bysource)
+ 		return -ENOMEM;
+ 
++	nf_nat_by_manip_src = nf_ct_alloc_hashtable(&nf_nat_htable_size, 0);
++	if (!nf_nat_by_manip_src)
++		return -ENOMEM;
++
+ 	ret = nf_ct_extend_register(&nat_extend);
+ 	if (ret < 0) {
+ 		nf_ct_free_hashtable(nf_nat_bysource, nf_nat_htable_size);
++		nf_ct_free_hashtable(nf_nat_by_manip_src, nf_nat_htable_size);
+ 		printk(KERN_ERR "nf_nat_core: Unable to register extension\n");
+ 		return ret;
+ 	}
+@@ -845,6 +986,7 @@ static int __init nf_nat_init(void)
+ 
+  cleanup_extend:
+ 	nf_ct_free_hashtable(nf_nat_bysource, nf_nat_htable_size);
++	nf_ct_free_hashtable(nf_nat_by_manip_src, nf_nat_htable_size);
+ 	nf_ct_extend_unregister(&nat_extend);
+ 	return ret;
+ }
+@@ -866,6 +1008,7 @@ static void __exit nf_nat_cleanup(void)
+ 		kfree(nf_nat_l4protos[i]);
+ 	synchronize_net();
+ 	nf_ct_free_hashtable(nf_nat_bysource, nf_nat_htable_size);
++	nf_ct_free_hashtable(nf_nat_by_manip_src, nf_nat_htable_size);
+ }
+ 
+ MODULE_LICENSE("GPL");
+diff --git a/net/netfilter/nf_nat_proto_common.c b/net/netfilter/nf_nat_proto_common.c
+index 7d7466d..fe13b74 100644
+--- a/net/netfilter/nf_nat_proto_common.c
++++ b/net/netfilter/nf_nat_proto_common.c
+@@ -34,7 +34,7 @@ bool nf_nat_l4proto_in_range(const struct nf_conntrack_tuple *tuple,
+ }
+ EXPORT_SYMBOL_GPL(nf_nat_l4proto_in_range);
+ 
+-void nf_nat_l4proto_unique_tuple(const struct nf_nat_l3proto *l3proto,
++int nf_nat_l4proto_unique_tuple(const struct nf_nat_l3proto *l3proto,
+ 				 struct nf_conntrack_tuple *tuple,
+ 				 const struct nf_nat_range *range,
+ 				 enum nf_nat_manip_type maniptype,
+@@ -54,7 +54,7 @@ void nf_nat_l4proto_unique_tuple(const struct nf_nat_l3proto *l3proto,
+ 	if (!(range->flags & NF_NAT_RANGE_PROTO_SPECIFIED)) {
+ 		/* If it's dst rewrite, can't change port */
+ 		if (maniptype == NF_NAT_MANIP_DST)
+-			return;
++			return 0;
+ 
+ 		if (ntohs(*portptr) < 1024) {
+ 			/* Loose convention: >> 512 is credential passing */
+@@ -85,16 +85,27 @@ void nf_nat_l4proto_unique_tuple(const struct nf_nat_l3proto *l3proto,
+ 		off = prandom_u32();
+ 	} else {
+ 		off = *rover;
++		if ((range->flags & NF_NAT_RANGE_FULLCONE) && (maniptype == NF_NAT_MANIP_SRC)) {
++			/* Try from the next L4 port in the range */
++			off++;
++		}
+ 	}
+ 
+-	for (i = 0; ; ++off) {
++	for (i = 0; (i != range_size); ++i, ++off) {
+ 		*portptr = htons(min + off % range_size);
+-		if (++i != range_size && nf_nat_used_tuple(tuple, ct))
+-			continue;
++
++		if ((range->flags & NF_NAT_RANGE_FULLCONE) && (maniptype == NF_NAT_MANIP_SRC)) {
++			if (nf_nat_used_3_tuple(tuple, ct, maniptype))
++				continue;
++		} else {
++			if (nf_nat_used_tuple(tuple, ct))
++				continue;
++		}
+ 		if (!(range->flags & NF_NAT_RANGE_PROTO_RANDOM_ALL))
+ 			*rover = off;
+-		return;
++		return 1;
+ 	}
++	return 0;
+ }
+ EXPORT_SYMBOL_GPL(nf_nat_l4proto_unique_tuple);
+ 
+diff --git a/net/netfilter/nf_nat_proto_dccp.c b/net/netfilter/nf_nat_proto_dccp.c
+index 15c47b2..48d22d4 100644
+--- a/net/netfilter/nf_nat_proto_dccp.c
++++ b/net/netfilter/nf_nat_proto_dccp.c
+@@ -22,15 +22,15 @@
+ 
+ static u_int16_t dccp_port_rover;
+ 
+-static void
++static int
+ dccp_unique_tuple(const struct nf_nat_l3proto *l3proto,
+ 		  struct nf_conntrack_tuple *tuple,
+ 		  const struct nf_nat_range *range,
+ 		  enum nf_nat_manip_type maniptype,
+ 		  const struct nf_conn *ct)
+ {
+-	nf_nat_l4proto_unique_tuple(l3proto, tuple, range, maniptype, ct,
+-				    &dccp_port_rover);
++	return nf_nat_l4proto_unique_tuple(l3proto, tuple, range, maniptype, ct,
++					   &dccp_port_rover);
+ }
+ 
+ static bool
+diff --git a/net/netfilter/nf_nat_proto_sctp.c b/net/netfilter/nf_nat_proto_sctp.c
+index cbc7ade..c765cbc 100644
+--- a/net/netfilter/nf_nat_proto_sctp.c
++++ b/net/netfilter/nf_nat_proto_sctp.c
+@@ -16,15 +16,15 @@
+ 
+ static u_int16_t nf_sctp_port_rover;
+ 
+-static void
++static int
+ sctp_unique_tuple(const struct nf_nat_l3proto *l3proto,
+ 		  struct nf_conntrack_tuple *tuple,
+ 		  const struct nf_nat_range *range,
+ 		  enum nf_nat_manip_type maniptype,
+ 		  const struct nf_conn *ct)
+ {
+-	nf_nat_l4proto_unique_tuple(l3proto, tuple, range, maniptype, ct,
+-				    &nf_sctp_port_rover);
++	return nf_nat_l4proto_unique_tuple(l3proto, tuple, range, maniptype, ct,
++					   &nf_sctp_port_rover);
+ }
+ 
+ static bool
+diff --git a/net/netfilter/nf_nat_proto_tcp.c b/net/netfilter/nf_nat_proto_tcp.c
+index 4f8820f..1cb5e69 100644
+--- a/net/netfilter/nf_nat_proto_tcp.c
++++ b/net/netfilter/nf_nat_proto_tcp.c
+@@ -20,15 +20,15 @@
+ 
+ static u16 tcp_port_rover;
+ 
+-static void
++static int
+ tcp_unique_tuple(const struct nf_nat_l3proto *l3proto,
+ 		 struct nf_conntrack_tuple *tuple,
+ 		 const struct nf_nat_range *range,
+ 		 enum nf_nat_manip_type maniptype,
+ 		 const struct nf_conn *ct)
+ {
+-	nf_nat_l4proto_unique_tuple(l3proto, tuple, range, maniptype, ct,
+-				    &tcp_port_rover);
++	return nf_nat_l4proto_unique_tuple(l3proto, tuple, range, maniptype, ct,
++					   &tcp_port_rover);
+ }
+ 
+ static bool
+diff --git a/net/netfilter/nf_nat_proto_udp.c b/net/netfilter/nf_nat_proto_udp.c
+index b1e6272..f7e8b04 100644
+--- a/net/netfilter/nf_nat_proto_udp.c
++++ b/net/netfilter/nf_nat_proto_udp.c
+@@ -19,15 +19,15 @@
+ 
+ static u16 udp_port_rover;
+ 
+-static void
++static int
+ udp_unique_tuple(const struct nf_nat_l3proto *l3proto,
+ 		 struct nf_conntrack_tuple *tuple,
+ 		 const struct nf_nat_range *range,
+ 		 enum nf_nat_manip_type maniptype,
+ 		 const struct nf_conn *ct)
+ {
+-	nf_nat_l4proto_unique_tuple(l3proto, tuple, range, maniptype, ct,
+-				    &udp_port_rover);
++	return nf_nat_l4proto_unique_tuple(l3proto, tuple, range, maniptype, ct,
++					   &udp_port_rover);
+ }
+ 
+ static bool
+diff --git a/net/netfilter/nf_nat_proto_udplite.c b/net/netfilter/nf_nat_proto_udplite.c
+index 58340c9..56b06fe 100644
+--- a/net/netfilter/nf_nat_proto_udplite.c
++++ b/net/netfilter/nf_nat_proto_udplite.c
+@@ -19,15 +19,15 @@
+ 
+ static u16 udplite_port_rover;
+ 
+-static void
++static int
+ udplite_unique_tuple(const struct nf_nat_l3proto *l3proto,
+ 		     struct nf_conntrack_tuple *tuple,
+ 		     const struct nf_nat_range *range,
+ 		     enum nf_nat_manip_type maniptype,
+ 		     const struct nf_conn *ct)
+ {
+-	nf_nat_l4proto_unique_tuple(l3proto, tuple, range, maniptype, ct,
+-				    &udplite_port_rover);
++	return nf_nat_l4proto_unique_tuple(l3proto, tuple, range, maniptype, ct,
++					   &udplite_port_rover);
+ }
+ 
+ static bool
+diff --git a/net/netfilter/nf_nat_proto_unknown.c b/net/netfilter/nf_nat_proto_unknown.c
+index 6e494d5..4ad71c8 100644
+--- a/net/netfilter/nf_nat_proto_unknown.c
++++ b/net/netfilter/nf_nat_proto_unknown.c
+@@ -25,7 +25,7 @@ static bool unknown_in_range(const struct nf_conntrack_tuple *tuple,
+ 	return true;
+ }
+ 
+-static void unknown_unique_tuple(const struct nf_nat_l3proto *l3proto,
++static int unknown_unique_tuple(const struct nf_nat_l3proto *l3proto,
+ 				 struct nf_conntrack_tuple *tuple,
+ 				 const struct nf_nat_range *range,
+ 				 enum nf_nat_manip_type maniptype,
+@@ -34,7 +34,7 @@ static void unknown_unique_tuple(const struct nf_nat_l3proto *l3proto,
+ 	/* Sorry: we can't help you; if it's not unique, we can't frob
+ 	 * anything.
+ 	 */
+-	return;
++	return 0;
+ }
+ 
+ static bool
+-- 
+2.18.0
+

--- a/patch/driver-ixgbe-external-phy.patch
+++ b/patch/driver-ixgbe-external-phy.patch
@@ -1,0 +1,57 @@
+From: Jostar Yang <jostar_yang@accton.com>
+Signed-off-by: Jostar Yang <jostar_yang@accton.com>
+
+
+diff --git a/drivers/net/ethernet/intel/ixgbe/ixgbe_phy.c b/drivers/net/ethernet/intel/ixgbe/ixgbe_phy.c
+index b17464e..29d267d 100644
+--- a/drivers/net/ethernet/intel/ixgbe/ixgbe_phy.c
++++ b/drivers/net/ethernet/intel/ixgbe/ixgbe_phy.c
+@@ -429,6 +429,9 @@ static enum ixgbe_phy_type ixgbe_get_phy_type_from_id(u32 phy_id)
+ 	case X557_PHY_ID:
+ 		phy_type = ixgbe_phy_x550em_ext_t;
+ 		break;
++	case BCM54616S_E_PHY_ID:
++		phy_type = ixgbe_phy_ext_1g_t;
++		break;
+ 	default:
+ 		phy_type = ixgbe_phy_unknown;
+ 		break;
+diff --git a/drivers/net/ethernet/intel/ixgbe/ixgbe_type.h b/drivers/net/ethernet/intel/ixgbe/ixgbe_type.h
+index 31d82e3..94d6306 100644
+--- a/drivers/net/ethernet/intel/ixgbe/ixgbe_type.h
++++ b/drivers/net/ethernet/intel/ixgbe/ixgbe_type.h
+@@ -1401,6 +1401,7 @@ struct ixgbe_thermal_sensor_data {
+ 
+ /* PHY Types */
+ #define IXGBE_M88E1145_E_PHY_ID  0x01410CD0
++#define BCM54616S_E_PHY_ID       0x03625D10
+ 
+ /* Special PHY Init Routine */
+ #define IXGBE_PHY_INIT_OFFSET_NL 0x002B
+@@ -3060,6 +3061,7 @@ enum ixgbe_phy_type {
+ 	ixgbe_phy_x550em_kr,
+ 	ixgbe_phy_x550em_kx4,
+ 	ixgbe_phy_x550em_ext_t,
++	ixgbe_phy_ext_1g_t,
+ 	ixgbe_phy_cu_unknown,
+ 	ixgbe_phy_qt,
+ 	ixgbe_phy_xaui,
+diff --git a/drivers/net/ethernet/intel/ixgbe/ixgbe_x550.c b/drivers/net/ethernet/intel/ixgbe/ixgbe_x550.c
+index 8466f38..033b2eb 100644
+--- a/drivers/net/ethernet/intel/ixgbe/ixgbe_x550.c
++++ b/drivers/net/ethernet/intel/ixgbe/ixgbe_x550.c
+@@ -1716,8 +1716,12 @@ static s32 ixgbe_get_link_capabilities_X550em(struct ixgbe_hw *hw,
+ 		else
+ 			*speed = IXGBE_LINK_SPEED_10GB_FULL;
+ 	} else {
+-		*speed = IXGBE_LINK_SPEED_10GB_FULL |
+-			 IXGBE_LINK_SPEED_1GB_FULL;
++		if (hw->phy.type == ixgbe_phy_ext_1g_t) {
++			*speed = IXGBE_LINK_SPEED_1GB_FULL;
++		} else {
++			*speed = IXGBE_LINK_SPEED_10GB_FULL |
++			IXGBE_LINK_SPEED_1GB_FULL;
++		}
+ 		*autoneg = true;
+ 	}
+ 	return 0;

--- a/patch/fix_ismt_alignment_issue.patch
+++ b/patch/fix_ismt_alignment_issue.patch
@@ -1,0 +1,141 @@
+From Commit ID: 5cd5f0bb0d9c32876b3d86b70fb45da10d028be7
+Subject: I2C ISMT  16-byte align the DMA buffer address
+
+Use only a portion of the data buffer for DMA transfers, which is always
+16-byte aligned. This makes the DMA buffer address 16-byte aligned and
+compensates for spurious hardware parity errors that may appear when the
+DMA buffer address is not 16-byte aligned.
+
+The data buffer is enlarged in order to accommodate any possible 16-byte
+alignment offset and changes the DMA code to only use a portion of the
+data buffer, which is 16-byte aligned.
+
+The symptom of the hardware issue is the same as the one addressed in
+v3.12-rc2-5-gbf41691 and manifests by transfers failing with EIO, with
+bit 9 being set in the ERRSTS register.
+
+Signed-off-by: Radu Rendec <radu.rendec@gmail.com>
+Acked-by: Neil Horman <nhorman@tuxdriver.com>
+Signed-off-by: Wolfram Sang <wsa@the-dreams.de>
+---
+
+diff --git a/drivers/i2c/busses/i2c-ismt.c b/drivers/i2c/busses/i2c-ismt.c
+index c97b48c..91c6524 100644
+--- a/drivers/i2c/busses/i2c-ismt.c
++++ b/drivers/i2c/busses/i2c-ismt.c
+@@ -173,7 +173,7 @@ struct ismt_priv {
+ 	dma_addr_t io_rng_dma;			/* descriptor HW base addr */
+ 	u8 head;				/* ring buffer head pointer */
+ 	struct completion cmp;			/* interrupt completion */
+-	u8 dma_buffer[I2C_SMBUS_BLOCK_MAX + 1];	/* temp R/W data buffer */
++	u8 buffer[I2C_SMBUS_BLOCK_MAX + 16];	/* temp R/W data buffer */
+ };
+ 
+ /**
+@@ -324,7 +324,7 @@ static int ismt_process_desc(const struct ismt_desc *desc,
+ 			     struct ismt_priv *priv, int size,
+ 			     char read_write)
+ {
+-	u8 *dma_buffer = priv->dma_buffer;
++	u8 *dma_buffer = PTR_ALIGN(&priv->buffer[0], 16);
+ 
+ 	dev_dbg(&priv->pci_dev->dev, "Processing completed descriptor\n");
+ 	__ismt_desc_dump(&priv->pci_dev->dev, desc);
+@@ -397,6 +397,7 @@ static int ismt_access(struct i2c_adapter *adap, u16 addr,
+ 	struct ismt_desc *desc;
+ 	struct ismt_priv *priv = i2c_get_adapdata(adap);
+ 	struct device *dev = &priv->pci_dev->dev;
++	u8 *dma_buffer =  PTR_ALIGN(&priv->buffer[0], 16);
+ 
+ 	if (delay > 0)
+ 		udelay(delay);
+@@ -404,7 +405,7 @@ static int ismt_access(struct i2c_adapter *adap, u16 addr,
+ 	desc = &priv->hw[priv->head];
+ 
+ 	/* Initialize the DMA buffer */
+-	memset(priv->dma_buffer, 0, sizeof(priv->dma_buffer));
++	memset(priv->buffer, 0, sizeof(priv->buffer));
+ 
+ 	/* Initialize the descriptor */
+ 	memset(desc, 0, sizeof(struct ismt_desc));
+@@ -453,8 +454,8 @@ static int ismt_access(struct i2c_adapter *adap, u16 addr,
+ 			desc->wr_len_cmd = 2;
+ 			dma_size = 2;
+ 			dma_direction = DMA_TO_DEVICE;
+-			priv->dma_buffer[0] = command;
+-			priv->dma_buffer[1] = data->byte;
++			dma_buffer[0] = command;
++			dma_buffer[1] = data->byte;
+ 		} else {
+ 			/* Read Byte */
+ 			dev_dbg(dev, "I2C_SMBUS_BYTE_DATA:  READ\n");
+@@ -473,9 +474,9 @@ static int ismt_access(struct i2c_adapter *adap, u16 addr,
+ 			desc->wr_len_cmd = 3;
+ 			dma_size = 3;
+ 			dma_direction = DMA_TO_DEVICE;
+-			priv->dma_buffer[0] = command;
+-			priv->dma_buffer[1] = data->word & 0xff;
+-			priv->dma_buffer[2] = data->word >> 8;
++			dma_buffer[0] = command;
++			dma_buffer[1] = data->word & 0xff;
++			dma_buffer[2] = data->word >> 8;
+ 		} else {
+ 			/* Read Word */
+ 			dev_dbg(dev, "I2C_SMBUS_WORD_DATA:  READ\n");
+@@ -493,9 +494,9 @@ static int ismt_access(struct i2c_adapter *adap, u16 addr,
+ 		desc->rd_len = 2;
+ 		dma_size = 3;
+ 		dma_direction = DMA_BIDIRECTIONAL;
+-		priv->dma_buffer[0] = command;
+-		priv->dma_buffer[1] = data->word & 0xff;
+-		priv->dma_buffer[2] = data->word >> 8;
++		dma_buffer[0] = command;
++		dma_buffer[1] = data->word & 0xff;
++		dma_buffer[2] = data->word >> 8;
+ 		break;
+ 
+ 	case I2C_SMBUS_BLOCK_DATA:
+@@ -506,8 +507,8 @@ static int ismt_access(struct i2c_adapter *adap, u16 addr,
+ 			dma_direction = DMA_TO_DEVICE;
+ 			desc->wr_len_cmd = dma_size;
+ 			desc->control |= ISMT_DESC_BLK;
+-			priv->dma_buffer[0] = command;
+-			memcpy(&priv->dma_buffer[1], &data->block[1], dma_size - 1);
++			dma_buffer[0] = command;
++			memcpy(&dma_buffer[1], &data->block[1], dma_size - 1);
+ 		} else {
+ 			/* Block Read */
+ 			dev_dbg(dev, "I2C_SMBUS_BLOCK_DATA:  READ\n");
+@@ -534,8 +535,8 @@ static int ismt_access(struct i2c_adapter *adap, u16 addr,
+ 			dma_direction = DMA_TO_DEVICE;
+ 			desc->wr_len_cmd = dma_size;
+ 			desc->control |= ISMT_DESC_I2C;
+-			priv->dma_buffer[0] = command;
+-			memcpy(&priv->dma_buffer[1], &data->block[1], dma_size - 1);
++			dma_buffer[0] = command;
++			memcpy(&dma_buffer[1], &data->block[1], dma_size - 1);
+ 		} else {
+ 			/* i2c Block Read */
+ 			dev_dbg(dev, "I2C_SMBUS_I2C_BLOCK_DATA:  READ\n");
+@@ -564,18 +565,18 @@ static int ismt_access(struct i2c_adapter *adap, u16 addr,
+ 	if (dma_size != 0) {
+ 		dev_dbg(dev, " dev=%p\n", dev);
+ 		dev_dbg(dev, " data=%p\n", data);
+-		dev_dbg(dev, " dma_buffer=%p\n", priv->dma_buffer);
++		dev_dbg(dev, " dma_buffer=%p\n", dma_buffer);
+ 		dev_dbg(dev, " dma_size=%d\n", dma_size);
+ 		dev_dbg(dev, " dma_direction=%d\n", dma_direction);
+ 
+ 		dma_addr = dma_map_single(dev,
+-				      priv->dma_buffer,
++				      dma_buffer,
+ 				      dma_size,
+ 				      dma_direction);
+ 
+ 		if (dma_mapping_error(dev, dma_addr)) {
+ 			dev_err(dev, "Error in mapping dma buffer %p\n",
+-				priv->dma_buffer);
++				dma_buffer);
+ 			return -EIO;
+ 		}
+ 

--- a/patch/net-backport-ipv6-missing-route.patch
+++ b/patch/net-backport-ipv6-missing-route.patch
@@ -1,0 +1,34 @@
+The below patch has been backported to fix "ipv6: Handle missing host route in __ipv6_ifa_notify"
+
+https://github.com/torvalds/linux/commit/2d819d250a1393a3e725715425ab70a0e0772a71#diff-0907850728440370acc820310df76f30
+
+diff --git a/net/ipv6/addrconf.c b/net/ipv6/addrconf.c
+index cb5aaf4..79c1012 100644
+--- a/net/ipv6/addrconf.c
++++ b/net/ipv6/addrconf.c
+@@ -5402,13 +5402,20 @@ static void __ipv6_ifa_notify(int event, struct inet6_ifaddr *ifp)
+ 	switch (event) {
+ 	case RTM_NEWADDR:
+ 		/*
+-		 * If the address was optimistic
+-		 * we inserted the route at the start of
+-		 * our DAD process, so we don't need
+-		 * to do it again
++		 * If the address was optimistic we inserted the route at the
++		 * start of our DAD process, so we don't need to do it again.
++		 * If the device was taken down in the middle of the DAD
++		 * cycle there is a race where we could get here without a
++		 * host route, so nothing to insert. That will be fixed when
++		 * the device is brought up.
+ 		 */
+-		if (!rcu_access_pointer(ifp->rt->rt6i_node))
++		if (ifp->rt && !rcu_access_pointer(ifp->rt->rt6i_node)) {
+ 			ip6_ins_rt(ifp->rt);
++		} else if (!ifp->rt && (ifp->idev->dev->flags & IFF_UP)) {
++			pr_warn("BUG: Address %pI6c on device %s is missing its host route.\n",
++				&ifp->addr, ifp->idev->dev->name);
++		}
++
+ 		if (ifp->idev->cnf.forwarding)
+ 			addrconf_join_anycast(ifp);
+ 		if (!ipv6_addr_any(&ifp->peer_addr))

--- a/patch/net-psample-fix-skb-over-panic.patch
+++ b/patch/net-psample-fix-skb-over-panic.patch
@@ -1,0 +1,92 @@
+From 7eb9d7675c08937cd11d32b0b40442d4d731c5ee Mon Sep 17 00:00:00 2001
+From: Nikolay Aleksandrov <nikolay@cumulusnetworks.com>
+Date: Wed, 27 Nov 2019 00:16:44 +0200
+Subject: [PATCH] net: psample: fix skb_over_panic
+
+We need to calculate the skb size correctly otherwise we risk triggering
+skb_over_panic[1]. The issue is that data_len is added to the skb in a
+nl attribute, but we don't account for its header size (nlattr 4 bytes)
+and alignment. We account for it when calculating the total size in
+the > PSAMPLE_MAX_PACKET_SIZE comparison correctly, but not when
+allocating after that. The fix is simple - use nla_total_size() for
+data_len when allocating.
+
+To reproduce:
+ $ tc qdisc add dev eth1 clsact
+ $ tc filter add dev eth1 egress matchall action sample rate 1 group 1 trunc 129
+ $ mausezahn eth1 -b bcast -a rand -c 1 -p 129
+ < skb_over_panic BUG(), tail is 4 bytes past skb->end >
+
+[1] Trace:
+ [   50.459526][ T3480] skbuff: skb_over_panic: text:(____ptrval____) len:196 put:136 head:(____ptrval____) data:(____ptrval____) tail:0xc4 end:0xc0 dev:<NULL>
+ [   50.474339][ T3480] ------------[ cut here ]------------
+ [   50.481132][ T3480] kernel BUG at net/core/skbuff.c:108!
+ [   50.486059][ T3480] invalid opcode: 0000 [#1] PREEMPT SMP
+ [   50.489463][ T3480] CPU: 3 PID: 3480 Comm: mausezahn Not tainted 5.4.0-rc7 #108
+ [   50.492844][ T3480] Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.12.0-2.fc30 04/01/2014
+ [   50.496551][ T3480] RIP: 0010:skb_panic+0x79/0x7b
+ [   50.498261][ T3480] Code: bc 00 00 00 41 57 4c 89 e6 48 c7 c7 90 29 9a 83 4c 8b 8b c0 00 00 00 50 8b 83 b8 00 00 00 50 ff b3 c8 00 00 00 e8 ae ef c0 fe <0f> 0b e8 2f df c8 fe 48 8b 55 08 44 89 f6 4c 89 e7 48 c7 c1 a0 22
+ [   50.504111][ T3480] RSP: 0018:ffffc90000447a10 EFLAGS: 00010282
+ [   50.505835][ T3480] RAX: 0000000000000087 RBX: ffff888039317d00 RCX: 0000000000000000
+ [   50.507900][ T3480] RDX: 0000000000000000 RSI: ffffffff812716e1 RDI: 00000000ffffffff
+ [   50.509820][ T3480] RBP: ffffc90000447a60 R08: 0000000000000001 R09: 0000000000000000
+ [   50.511735][ T3480] R10: ffffffff81d4f940 R11: 0000000000000000 R12: ffffffff834a22b0
+ [   50.513494][ T3480] R13: ffffffff82c10433 R14: 0000000000000088 R15: ffffffff838a8084
+ [   50.515222][ T3480] FS:  00007f3536462700(0000) GS:ffff88803eac0000(0000) knlGS:0000000000000000
+ [   50.517135][ T3480] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+ [   50.518583][ T3480] CR2: 0000000000442008 CR3: 000000003b222000 CR4: 00000000000006e0
+ [   50.520723][ T3480] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
+ [   50.522709][ T3480] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
+ [   50.524450][ T3480] Call Trace:
+ [   50.525214][ T3480]  skb_put.cold+0x1b/0x1b
+ [   50.526171][ T3480]  psample_sample_packet+0x1d3/0x340
+ [   50.527307][ T3480]  tcf_sample_act+0x178/0x250
+ [   50.528339][ T3480]  tcf_action_exec+0xb1/0x190
+ [   50.529354][ T3480]  mall_classify+0x67/0x90
+ [   50.530332][ T3480]  tcf_classify+0x72/0x160
+ [   50.531286][ T3480]  __dev_queue_xmit+0x3db/0xd50
+ [   50.532327][ T3480]  dev_queue_xmit+0x18/0x20
+ [   50.533299][ T3480]  packet_sendmsg+0xee7/0x2090
+ [   50.534331][ T3480]  sock_sendmsg+0x54/0x70
+ [   50.535271][ T3480]  __sys_sendto+0x148/0x1f0
+ [   50.536252][ T3480]  ? tomoyo_file_ioctl+0x23/0x30
+ [   50.537334][ T3480]  ? ksys_ioctl+0x5e/0xb0
+ [   50.540068][ T3480]  __x64_sys_sendto+0x2a/0x30
+ [   50.542810][ T3480]  do_syscall_64+0x73/0x1f0
+ [   50.545383][ T3480]  entry_SYSCALL_64_after_hwframe+0x44/0xa9
+ [   50.548477][ T3480] RIP: 0033:0x7f35357d6fb3
+ [   50.551020][ T3480] Code: 48 8b 0d 18 90 20 00 f7 d8 64 89 01 48 83 c8 ff c3 66 0f 1f 44 00 00 83 3d f9 d3 20 00 00 75 13 49 89 ca b8 2c 00 00 00 0f 05 <48> 3d 01 f0 ff ff 73 34 c3 48 83 ec 08 e8 eb f6 ff ff 48 89 04 24
+ [   50.558547][ T3480] RSP: 002b:00007ffe0c7212c8 EFLAGS: 00000246 ORIG_RAX: 000000000000002c
+ [   50.561870][ T3480] RAX: ffffffffffffffda RBX: 0000000001dac010 RCX: 00007f35357d6fb3
+ [   50.565142][ T3480] RDX: 0000000000000082 RSI: 0000000001dac2a2 RDI: 0000000000000003
+ [   50.568469][ T3480] RBP: 00007ffe0c7212f0 R08: 00007ffe0c7212d0 R09: 0000000000000014
+ [   50.571731][ T3480] R10: 0000000000000000 R11: 0000000000000246 R12: 0000000000000082
+ [   50.574961][ T3480] R13: 0000000001dac2a2 R14: 0000000000000001 R15: 0000000000000003
+ [   50.578170][ T3480] Modules linked in: sch_ingress virtio_net
+ [   50.580976][ T3480] ---[ end trace 61a515626a595af6 ]---
+
+CC: Yotam Gigi <yotamg@mellanox.com>
+CC: Jiri Pirko <jiri@mellanox.com>
+CC: Jamal Hadi Salim <jhs@mojatatu.com>
+CC: Simon Horman <simon.horman@netronome.com>
+CC: Roopa Prabhu <roopa@cumulusnetworks.com>
+Fixes: 6ae0a6286171 ("net: Introduce psample, a new genetlink channel for packet sampling")
+Signed-off-by: Nikolay Aleksandrov <nikolay@cumulusnetworks.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ net/psample/psample.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/net/psample/psample.c b/net/psample/psample.c
+index a6ceb0533b5bb..6f2fbc6b9eb2e 100644
+--- a/net/psample/psample.c
++++ b/net/psample/psample.c
+@@ -229,7 +229,7 @@ void psample_sample_packet(struct psample_group *group, struct sk_buff *skb,
+ 		data_len = PSAMPLE_MAX_PACKET_SIZE - meta_len - NLA_HDRLEN
+ 			    - NLA_ALIGNTO;
+ 
+-	nl_skb = genlmsg_new(meta_len + data_len, GFP_ATOMIC);
++	nl_skb = genlmsg_new(meta_len + nla_total_size(data_len), GFP_ATOMIC);
+ 	if (unlikely(!nl_skb))
+ 		return;
+ 

--- a/patch/preconfig/changelog.patch
+++ b/patch/preconfig/changelog.patch
@@ -13,19 +13,22 @@ diff --git a/debian/changelog b/debian/changelog
 index 026b840..88c8a43 100644
 --- a/debian/changelog
 +++ b/debian/changelog
-@@ -1,3 +1,15 @@
-+linux (4.9.168-1+deb9u5) sonic; urgency=high
+@@ -1248,6 +1248,18 @@
+ 
+  -- Salvatore Bonaccorso <carnil@debian.org>  Fri, 19 Jul 2019 13:41:00 +0200
+ 
++linux (4.9.168-1+deb9u3) sonic; urgency=high
 +
 +  * add driver patches for MLNX SN2700
 +
 + -- Guohan Lu <gulv@microsoft.com>  Sun, 19 Dec 2015 01:50:04 +0100
 +
-+linux (4.9.168-1+deb9u5) sonic; urgency=high
++linux (4.9.168-1+deb9u3) sonic; urgency=high
 +
 +  * add support for S6000
 +
 + -- Shuotian Cheng <shuche@microsoft.com>  Sun, 19 Dec 2015 01:50:04 +0100
 +
- linux (4.9.168-1+deb9u5) stretch-security; urgency=high
-
-   * [amd64] Add mitigation for Spectre v1 swapgs (CVE-2019-1125):
+ linux (4.9.168-1+deb9u3) stretch-security; urgency=high
+ 
+   [ Salvatore Bonaccorso ]

--- a/patch/preconfig/packaging-update-abiname-to-11-2.patch
+++ b/patch/preconfig/packaging-update-abiname-to-11-2.patch
@@ -13,8 +13,8 @@ index cfc4409..fae58f7 100644
 +++ b/debian/config/defines
 @@ -1,5 +1,5 @@
  [abi]
--abiname: 9
-+abiname: 9-2
+-abiname: 11
++abiname: 11-2
  ignore-changes:
   __cpuhp_*
   bpf_analyzer

--- a/patch/preconfig/series
+++ b/patch/preconfig/series
@@ -1,2 +1,2 @@
 changelog.patch
-packaging-update-abiname-to-9-2.patch
+packaging-update-abiname-to-11-2.patch

--- a/patch/series
+++ b/patch/series
@@ -96,6 +96,7 @@ kernel-enable-psample-and-act_sample-drivers.patch
 0000-net-ipv6-ll-anycast-mcast-routes-on-dev.patch
 0001-net-ipv6-Allow-shorthand-delete-of-all-nexthops-in-m.patch
 net-backport-ipv6-missing-route.patch
+Support-for-fullcone-nat.patch
 #
 # This series applies on GIT commit 1451b36b2b0d62178e42f648d8a18131af18f7d8
 # Tkernel-sched-core-fix-cgroup-fork-race.patch

--- a/patch/series
+++ b/patch/series
@@ -99,6 +99,7 @@ net-psample-fix-skb-over-panic.patch
 net-backport-ipv6-missing-route.patch
 Support-for-fullcone-nat.patch
 driver-ixgbe-external-phy.patch
+fix_ismt_alignment_issue.patch
 #
 # This series applies on GIT commit 1451b36b2b0d62178e42f648d8a18131af18f7d8
 # Tkernel-sched-core-fix-cgroup-fork-race.patch

--- a/patch/series
+++ b/patch/series
@@ -100,6 +100,8 @@ linux-4.13-thermal-intel_pch_thermal-Fix-enable-check-on.patch
 0062-platform-mellanox-mlxreg-hotplug-Use-capability-r.patch
 0063-platform-mellanox-mlxreg-io-Add-support-for-compl.patch
 0064-Add-config-for-sensor-xdpe122-and-modify-mlx_wdt-.patch
+0065-mlxsw-qsfp_sysfs-Remove-obsolete-code-for-QSFP-EEPRO.patch
+0066-platform-mellanox-mlxreg-hotplug-Add-environmental-d.patch
 linux-4.16-firmware-dmi-handle-missing-DMI-data-gracefully.patch
 mellanox-backport-introduce-psample-a-new-genetlink-channel.patch
 mellanox-backport-introduce-tc-sample-action.patch

--- a/patch/series
+++ b/patch/series
@@ -98,6 +98,7 @@ net-psample-fix-skb-over-panic.patch
 0001-net-ipv6-Allow-shorthand-delete-of-all-nexthops-in-m.patch
 net-backport-ipv6-missing-route.patch
 Support-for-fullcone-nat.patch
+driver-ixgbe-external-phy.patch
 #
 # This series applies on GIT commit 1451b36b2b0d62178e42f648d8a18131af18f7d8
 # Tkernel-sched-core-fix-cgroup-fork-race.patch

--- a/patch/series
+++ b/patch/series
@@ -83,6 +83,11 @@ linux-4.13-thermal-intel_pch_thermal-Fix-enable-check-on.patch
 0045-mlxsw-minimal-Add-validation-for-FW-version.patch
 0046-mlxsw-core-Extend-QSFP-EEPROM-supported-size-for-eth.patch
 0047-mfd-lpc-ich-extend-with-additional-chipsets-support.patch
+0048-mlxsw-core-Skip-thermal-zone-operations-initializati.patch
+0049-thermal-Fix-use-after-free-when-unregistering-therma.patch
+0050-mlxsw-core-Drop-creation-of-thermal-to-hwmon-sysfs-i.patch
+0051-mlxsw-core-Skip-thermal-zones-threshold-setting-duri.patch
+0052-platform-x86-mlx-platform-Add-more-detention-for-sys.patch
 linux-4.16-firmware-dmi-handle-missing-DMI-data-gracefully.patch
 mellanox-backport-introduce-psample-a-new-genetlink-channel.patch
 mellanox-backport-introduce-tc-sample-action.patch

--- a/patch/series
+++ b/patch/series
@@ -88,6 +88,11 @@ linux-4.13-thermal-intel_pch_thermal-Fix-enable-check-on.patch
 0050-mlxsw-core-Drop-creation-of-thermal-to-hwmon-sysfs-i.patch
 0051-mlxsw-core-Skip-thermal-zones-threshold-setting-duri.patch
 0052-platform-x86-mlx-platform-Add-more-detention-for-sys.patch
+0053-firmware-dmi-Add-access-to-the-SKU-ID-string-backpor.patch
+0054-platform-x86-mlx-platform-Modify-setting-for-new-sys.patch
+0055-platform-x86-mlx-platform-Add-support-for-next-gener.patch
+0056-mlxsw-core-Add-support-for-new-hardware-device-types.patch
+0057-mlxsw-minimal-Fix-validation-for-FW-minor-version.patch
 linux-4.16-firmware-dmi-handle-missing-DMI-data-gracefully.patch
 mellanox-backport-introduce-psample-a-new-genetlink-channel.patch
 mellanox-backport-introduce-tc-sample-action.patch

--- a/patch/series
+++ b/patch/series
@@ -92,6 +92,7 @@ linux-4.16-firmware-dmi-handle-missing-DMI-data-gracefully.patch
 mellanox-backport-introduce-psample-a-new-genetlink-channel.patch
 mellanox-backport-introduce-tc-sample-action.patch
 kernel-enable-psample-and-act_sample-drivers.patch
+net-psample-fix-skb-over-panic.patch
 0000-net-Fix-netdev-adjacency-tracking.patch
 0000-net-ipv6-ll-anycast-mcast-routes-on-dev.patch
 0001-net-ipv6-Allow-shorthand-delete-of-all-nexthops-in-m.patch

--- a/patch/series
+++ b/patch/series
@@ -89,6 +89,7 @@ mellanox-backport-introduce-tc-sample-action.patch
 kernel-enable-psample-and-act_sample-drivers.patch
 0000-net-Fix-netdev-adjacency-tracking.patch
 0000-net-ipv6-ll-anycast-mcast-routes-on-dev.patch
+0001-net-ipv6-Allow-shorthand-delete-of-all-nexthops-in-m.patch
 #
 # This series applies on GIT commit 1451b36b2b0d62178e42f648d8a18131af18f7d8
 # Tkernel-sched-core-fix-cgroup-fork-race.patch

--- a/patch/series
+++ b/patch/series
@@ -90,6 +90,7 @@ kernel-enable-psample-and-act_sample-drivers.patch
 0000-net-Fix-netdev-adjacency-tracking.patch
 0000-net-ipv6-ll-anycast-mcast-routes-on-dev.patch
 0001-net-ipv6-Allow-shorthand-delete-of-all-nexthops-in-m.patch
+net-backport-ipv6-missing-route.patch
 #
 # This series applies on GIT commit 1451b36b2b0d62178e42f648d8a18131af18f7d8
 # Tkernel-sched-core-fix-cgroup-fork-race.patch

--- a/patch/series
+++ b/patch/series
@@ -93,6 +93,8 @@ linux-4.13-thermal-intel_pch_thermal-Fix-enable-check-on.patch
 0055-platform-x86-mlx-platform-Add-support-for-next-gener.patch
 0056-mlxsw-core-Add-support-for-new-hardware-device-types.patch
 0057-mlxsw-minimal-Fix-validation-for-FW-minor-version.patch
+0058-mlxsw-core-thermal-Set-default-thermal-trips-at-init.patch
+0059-mlxsw-core-Add-the-hottest-thermal-zone-detection.patch
 linux-4.16-firmware-dmi-handle-missing-DMI-data-gracefully.patch
 mellanox-backport-introduce-psample-a-new-genetlink-channel.patch
 mellanox-backport-introduce-tc-sample-action.patch

--- a/patch/series
+++ b/patch/series
@@ -95,6 +95,11 @@ linux-4.13-thermal-intel_pch_thermal-Fix-enable-check-on.patch
 0057-mlxsw-minimal-Fix-validation-for-FW-minor-version.patch
 0058-mlxsw-core-thermal-Set-default-thermal-trips-at-init.patch
 0059-mlxsw-core-Add-the-hottest-thermal-zone-detection.patch
+0060-hwmon-pmbus-core-Add-support-for-vid-mode-detecti.patch
+0061-i2c-busses-i2c-mlxcpld-Increase-transaction-pooli.patch
+0062-platform-mellanox-mlxreg-hotplug-Use-capability-r.patch
+0063-platform-mellanox-mlxreg-io-Add-support-for-compl.patch
+0064-Add-config-for-sensor-xdpe122-and-modify-mlx_wdt-.patch
 linux-4.16-firmware-dmi-handle-missing-DMI-data-gracefully.patch
 mellanox-backport-introduce-psample-a-new-genetlink-channel.patch
 mellanox-backport-introduce-tc-sample-action.patch


### PR DESCRIPTION
Added four patches along with hw-mgmt V.7.0000.3034:
0058-mlxsw-qsfp_sysfs-Remove-obsolete-code-for-QSFP-EEPRO.patch
0059-platform-mellanox-mlxreg-hotplug-Add-environmental-d.patch